### PR TITLE
Muzero policy for generating a sequence of actions

### DIFF
--- a/mctx/__init__.py
+++ b/mctx/__init__.py
@@ -25,6 +25,7 @@ from mctx._src.base import RootActionSelectionFn
 from mctx._src.base import RootFnOutput
 from mctx._src.policies import gumbel_muzero_policy
 from mctx._src.policies import muzero_policy
+from mctx._src.policies import muzero_policy_for_action_sequence
 from mctx._src.qtransforms import qtransform_by_min_max
 from mctx._src.qtransforms import qtransform_by_parent_and_siblings
 from mctx._src.qtransforms import qtransform_completed_by_mix_value
@@ -46,6 +47,7 @@ __all__ = (
     "gumbel_muzero_root_action_selection",
     "muzero_action_selection",
     "muzero_policy",
+    "muzero_policy_for_action_sequence",
     "qtransform_by_min_max",
     "qtransform_by_parent_and_siblings",
     "qtransform_completed_by_mix_value",

--- a/mctx/_src/policies.py
+++ b/mctx/_src/policies.py
@@ -175,6 +175,15 @@ def muzero_policy_for_action_sequence(
     `PolicyOutput` containing the proposed action, action_weights and the used
     search tree.
   """
+  if invalid_actions is not None:
+    raise NotImplementedError(
+      "`invalid_actions` are not supported as the root position in the tree"
+      " changes, but `mctx._src.search.simulate` starts always at depth zero,"
+      " taking into account the old invalid_actions of the initial root."
+      " To support this, a redesign is needed: 1. Are invalid actions different"
+      " for different nodes in the tree, or does only the root have invalid"
+      " actions? 2. Where to fetch invalid_actions of non-root nodes during"
+      " the search?")
 
   from mctx import Tree
   from mctx._src.search import simulate, expand, backward, instantiate_tree_from_root

--- a/mctx/_src/policies.py
+++ b/mctx/_src/policies.py
@@ -207,7 +207,7 @@ def gumbel_muzero_policy(
   considered_visit = jnp.max(summary.visit_counts, axis=-1, keepdims=True)
   # The completed_qvalues include imputed values for unvisited actions.
   completed_qvalues = jax.vmap(qtransform, in_axes=[0, None])(
-      search_tree, search_tree.ROOT_INDEX)
+      search_tree, search_tree.INITIAL_ROOT_INDEX)
   to_argmax = seq_halving.score_considered(
       considered_visit, gumbel, root.prior_logits, completed_qvalues,
       summary.visit_counts)

--- a/mctx/_src/policies.py
+++ b/mctx/_src/policies.py
@@ -220,7 +220,7 @@ def muzero_policy_for_action_sequence(
   batch_size = root.value.shape[0]
   batch_range = jnp.arange(batch_size)
   if max_depth is None:
-    max_depth = num_simulations
+    max_depth = num_simulations * num_actions_to_generate
   if invalid_actions is None:
     invalid_actions = jnp.zeros_like(root.prior_logits)
 

--- a/mctx/_src/search.py
+++ b/mctx/_src/search.py
@@ -254,13 +254,18 @@ def backward(
   """
 
   def cond_fun(loop_state):
-    _, _, index = loop_state
+    tree, _, index = loop_state
+    # TODO does this comparison work? What when some indices are -1?
     return index != tree.root_index
 
   def body_fun(loop_state):
     # Here we update the value of our parent, so we start by reversing.
     tree, leaf_value, index = loop_state
+
+    # TODO: parent can go negative (i.e. attain -1), not sure how it is handled.
+    #  Perhaps the last node (the one with index -1) is used as a dummy sink? Perhaps there is some clipping?
     parent = tree.parents[index]
+
     count = tree.node_visits[parent]
     action = tree.action_from_parent[index]
     reward = tree.children_rewards[parent, action]

--- a/mctx/_src/search.py
+++ b/mctx/_src/search.py
@@ -166,14 +166,12 @@ def simulate(
         depth=depth,
         is_continuing=is_continuing)
 
-  node_index = jnp.array(Tree.INITIAL_ROOT_INDEX, dtype=jnp.int32)
-  # node_index = tree.root_index
+  node_index = tree.root_index
   depth = jnp.zeros((), dtype=tree.children_prior_logits.dtype)
   initial_state = _SimulationState(
       rng_key=rng_key,
       node_index=tree.NO_PARENT,
       action=tree.NO_PARENT,
-      # action=jnp.full(node_index.shape, tree.NO_PARENT, dtype=jnp.int32),
       next_node_index=node_index,
       depth=depth,
       is_continuing=jnp.array(True))

--- a/mctx/_src/tests/mctx_test.py
+++ b/mctx/_src/tests/mctx_test.py
@@ -24,6 +24,7 @@ class MctxTest(absltest.TestCase):
   def test_import(self):
     self.assertTrue(hasattr(mctx, "gumbel_muzero_policy"))
     self.assertTrue(hasattr(mctx, "muzero_policy"))
+    self.assertTrue(hasattr(mctx, "muzero_policy_for_action_sequence"))
     self.assertTrue(hasattr(mctx, "qtransform_by_min_max"))
     self.assertTrue(hasattr(mctx, "qtransform_by_parent_and_siblings"))
     self.assertTrue(hasattr(mctx, "qtransform_completed_by_mix_value"))

--- a/mctx/_src/tests/muzero_for_action_sequence_test.py
+++ b/mctx/_src/tests/muzero_for_action_sequence_test.py
@@ -12,7 +12,7 @@ import numpy as np
 from mctx._src.tests.tree_test import _prepare_root, _prepare_recurrent_fn
 
 
-class TreeTest(parameterized.TestCase):
+class MuzeroForActionSequenceTest(parameterized.TestCase):
   def test_tree(self, draw_graph=False):
     with open("test_data/muzero_for_action_sequence_qtransform_tree.json", "rb") as fd:
       tree = json.load(fd)
@@ -27,12 +27,6 @@ class TreeTest(parameterized.TestCase):
         **tree["algorithm_config"].pop("qtransform_kwargs", {}))
 
     batch_size = 3
-    # To test the independence of the batch computation, we use different
-    # invalid actions for the other elements of the batch. The different batch
-    # elements will then have different search tree depths.
-    invalid_actions = np.zeros([batch_size, num_actions])
-    invalid_actions[1, 1:] = 1
-    invalid_actions[2, 2:] = 1
 
     def run_policy():
       return mctx.muzero_policy_for_action_sequence(
@@ -42,7 +36,6 @@ class TreeTest(parameterized.TestCase):
         recurrent_fn=_prepare_recurrent_fn(num_actions, **env_config),
         num_simulations=num_simulations,
         qtransform=qtransform,
-        invalid_actions=invalid_actions,
         **tree["algorithm_config"],
         num_actions_to_generate=3,
       )

--- a/mctx/_src/tests/muzero_for_action_sequence_test.py
+++ b/mctx/_src/tests/muzero_for_action_sequence_test.py
@@ -1,0 +1,61 @@
+"""A unit that verifies that multiaction-muzero-policy gives the expected sequence of actions."""
+import functools
+import json
+
+import chex
+from absl import logging
+from absl.testing import parameterized
+import jax
+import mctx
+import numpy as np
+
+from mctx._src.tests.tree_test import _prepare_root, _prepare_recurrent_fn
+
+
+class TreeTest(parameterized.TestCase):
+  def test_tree(self, draw_graph=False):
+    with open("test_data/muzero_for_action_sequence_qtransform_tree.json", "rb") as fd:
+      tree = json.load(fd)
+    assert tree["algorithm"] == "muzero_for_action_sequence"
+
+    env_config = tree["env_config"]
+    root = tree["tree"]
+    num_actions = len(root["child_stats"])
+    num_simulations = root["visit"] - 1
+    qtransform = functools.partial(
+        getattr(mctx, tree["algorithm_config"].pop("qtransform")),
+        **tree["algorithm_config"].pop("qtransform_kwargs", {}))
+
+    batch_size = 3
+    # To test the independence of the batch computation, we use different
+    # invalid actions for the other elements of the batch. The different batch
+    # elements will then have different search tree depths.
+    invalid_actions = np.zeros([batch_size, num_actions])
+    invalid_actions[1, 1:] = 1
+    invalid_actions[2, 2:] = 1
+
+    def run_policy():
+      return mctx.muzero_policy_for_action_sequence(
+        params=(),
+        rng_key=jax.random.PRNGKey(1),
+        root=_prepare_root(batch_size=batch_size, num_actions=num_actions),
+        recurrent_fn=_prepare_recurrent_fn(num_actions, **env_config),
+        num_simulations=num_simulations,
+        qtransform=qtransform,
+        invalid_actions=invalid_actions,
+        **tree["algorithm_config"],
+        num_actions_to_generate=3,
+      )
+
+    policy_output = jax.jit(run_policy)()
+    logging.info("Done search.")
+
+    if draw_graph:
+      from examples.visualization_demo import convert_tree_to_graph
+      graph = convert_tree_to_graph(policy_output.search_tree)
+      graph.draw("/tmp/multiaction-muzero-dotgraph.png", prog="dot")
+
+    expected_actions = np.array([[14, 14, 3],
+                                 [0, 9, 14],
+                                 [1, 7, 9]])
+    chex.assert_trees_all_close(policy_output.action, expected_actions)

--- a/mctx/_src/tests/muzero_for_action_sequence_test.py
+++ b/mctx/_src/tests/muzero_for_action_sequence_test.py
@@ -1,54 +1,127 @@
-"""A unit that verifies that multiaction-muzero-policy gives the expected sequence of actions."""
+"""A unit that verifies that muzero_policy_for_action_sequence
+ compiles for different number for steps and batch sizes."""
 import functools
-import json
 
-import chex
+import jax
 from absl import logging
 from absl.testing import parameterized
-import jax
-import mctx
-import numpy as np
 
+import mctx
 from mctx._src.tests.tree_test import _prepare_root, _prepare_recurrent_fn
 
 
+## Uncomment for debugging in order to be able to inspect values in the debugger:
+# from jax.config import config;
+# config.update('jax_disable_jit', True)
+
 class MuzeroForActionSequenceTest(parameterized.TestCase):
-  def test_tree(self, draw_graph=False):
-    with open("test_data/muzero_for_action_sequence_qtransform_tree.json", "rb") as fd:
-      tree = json.load(fd)
-    assert tree["algorithm"] == "muzero_for_action_sequence"
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_1_step(self, qtransform):
+    policy_output = self._run(1, 10, 1, qtransform, f"/tmp/muzero-for-action-sequence-1x10-{qtransform}.png")
+    print(policy_output)
 
-    env_config = tree["env_config"]
-    root = tree["tree"]
-    num_actions = len(root["child_stats"])
-    num_simulations = root["visit"] - 1
-    qtransform = functools.partial(
-        getattr(mctx, tree["algorithm_config"].pop("qtransform")),
-        **tree["algorithm_config"].pop("qtransform_kwargs", {}))
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_2_steps(self, qtransform):
+    policy_output = self._run(1, 10, 2, qtransform, f"/tmp/muzero-for-action-sequence-2x10-{qtransform}.png")
+    print(policy_output)
 
-    batch_size = 3
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_3_steps(self, qtransform):
+    policy_output = self._run(1, 10, 3, qtransform, f"/tmp/muzero-for-action-sequence-3x10-{qtransform}.png")
+    print(policy_output)
+
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_4_steps(self, qtransform):
+    policy_output = self._run(1, 10, 4, qtransform, f"/tmp/muzero-for-action-sequence-3x10-{qtransform}.png")
+    print(policy_output)
+
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_5_steps(self, qtransform):
+    policy_output = self._run(1, 10, 5, qtransform, f"/tmp/muzero-for-action-sequence-5x10-{qtransform}.png")
+    print(policy_output)
+
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_batch_1_step(self, qtransform):
+    policy_output = self._run(3, 10, 1, qtransform)
+    print(policy_output)
+
+  @parameterized.named_parameters(
+    ("qtransform_by_min_max", "qtransform_by_min_max"),
+    ("qtransform_by_parent_and_siblings", "qtransform_by_parent_and_siblings"),
+  )
+  def test_batch_3_steps(self, qtransform):
+    policy_output = self._run(3, 50, 3, qtransform)
+    print(policy_output)
+
+  def _run(self, batch_size, num_simulations, num_actions_to_generate,
+           qtransform, draw_graph_path=None):
+    num_actions = 82
+
+    algorithm_config = {
+      "dirichlet_alpha": 0.3,
+      "dirichlet_fraction": 0.0,
+      "pb_c_base": 19652,
+      "pb_c_init": 1.25,
+    }
+
+    if qtransform == "qtransform_by_min_max":
+      env_config = {
+        "discount": -1.0,
+        "zero_reward": True
+      }
+      qtransform_kwargs = {
+        "max_value": 1.0,
+        "min_value": -1.0
+      }
+    elif qtransform == "qtransform_by_parent_and_siblings":
+      env_config = {
+        "discount": 0.997,
+        "zero_reward": False
+      }
+      qtransform_kwargs = {}
+    else:
+      raise ValueError()
+
+    qtransform = functools.partial(getattr(mctx, qtransform), **qtransform_kwargs)
 
     def run_policy():
       return mctx.muzero_policy_for_action_sequence(
+        num_actions_to_generate=num_actions_to_generate,
+        num_simulations=num_simulations,
+        # return mctx.muzero_policy(
+        #   num_simulations=num_simulations * num_actions_to_generate,
         params=(),
         rng_key=jax.random.PRNGKey(1),
         root=_prepare_root(batch_size=batch_size, num_actions=num_actions),
         recurrent_fn=_prepare_recurrent_fn(num_actions, **env_config),
-        num_simulations=num_simulations,
         qtransform=qtransform,
-        **tree["algorithm_config"],
-        num_actions_to_generate=3,
+        **algorithm_config,
       )
 
     policy_output = jax.jit(run_policy)()
     logging.info("Done search.")
 
-    if draw_graph:
+    if draw_graph_path is not None:
       from examples.visualization_demo import convert_tree_to_graph
       graph = convert_tree_to_graph(policy_output.search_tree)
-      graph.draw("/tmp/multiaction-muzero-dotgraph.png", prog="dot")
+      graph.draw(draw_graph_path, prog="dot")
 
-    expected_actions = np.array([[14, 14, 3],
-                                 [0, 9, 14],
-                                 [1, 7, 9]])
-    chex.assert_trees_all_close(policy_output.action, expected_actions)
+    return policy_output

--- a/mctx/_src/tests/policies_test.py
+++ b/mctx/_src/tests/policies_test.py
@@ -217,7 +217,7 @@ class PoliciesTest(absltest.TestCase):
     # Testing max_depth.
     leaf, max_found_depth = _get_deepest_leaf(
         jax.tree_util.tree_map(lambda x: x[0], policy_output.search_tree),
-        policy_output.search_tree.ROOT_INDEX)
+        policy_output.search_tree.INITIAL_ROOT_INDEX)
     self.assertEqual(max_depth, max_found_depth)
     self.assertEqual(6, policy_output.search_tree.node_visits[0, leaf])
 

--- a/mctx/_src/tests/test_data/muzero_for_action_sequence_qtransform_tree.json
+++ b/mctx/_src/tests/test_data/muzero_for_action_sequence_qtransform_tree.json
@@ -1,0 +1,4914 @@
+{
+  "algorithm": "muzero_for_action_sequence",
+  "algorithm_config": {
+    "dirichlet_alpha": 0.3,
+    "dirichlet_fraction": 0.0,
+    "pb_c_base": 19652,
+    "pb_c_init": 1.25,
+    "qtransform": "qtransform_by_parent_and_siblings",
+    "qtransform_kwargs": {}
+  },
+  "env_config": {
+    "discount": 0.997,
+    "zero_reward": false
+  },
+  "tree": {
+    "child_stats": [
+      {
+        "action": 0,
+        "child_stats": [],
+        "prior": 0.031807259
+      },
+      {
+        "action": 1,
+        "child_stats": [],
+        "prior": 0.05470673
+      },
+      {
+        "action": 2,
+        "child_stats": [],
+        "prior": 0.021140829
+      },
+      {
+        "action": 3,
+        "child_stats": [],
+        "prior": 0.007827593
+      },
+      {
+        "action": 4,
+        "child_stats": [],
+        "prior": 0.025768386
+      },
+      {
+        "action": 5,
+        "child_stats": [],
+        "prior": 0.094184466
+      },
+      {
+        "action": 6,
+        "child_stats": [],
+        "prior": 0.016630026
+      },
+      {
+        "action": 7,
+        "child_stats": [
+          {
+            "action": 0,
+            "child_stats": [],
+            "prior": 0.071076982
+          },
+          {
+            "action": 1,
+            "child_stats": [],
+            "prior": 0.045428157
+          },
+          {
+            "action": 2,
+            "child_stats": [],
+            "prior": 0.0068420204
+          },
+          {
+            "action": 3,
+            "child_stats": [],
+            "prior": 0.0076094549
+          },
+          {
+            "action": 4,
+            "child_stats": [
+              {
+                "action": 0,
+                "child_stats": [],
+                "prior": 0.0077350312
+              },
+              {
+                "action": 1,
+                "child_stats": [],
+                "prior": 0.067054957
+              },
+              {
+                "action": 2,
+                "child_stats": [],
+                "prior": 0.047156814
+              },
+              {
+                "action": 3,
+                "child_stats": [],
+                "prior": 0.084907413
+              },
+              {
+                "action": 4,
+                "child_stats": [],
+                "prior": 0.021648079
+              },
+              {
+                "action": 5,
+                "child_stats": [],
+                "prior": 0.035587203
+              },
+              {
+                "action": 6,
+                "child_stats": [],
+                "prior": 0.035846647
+              },
+              {
+                "action": 7,
+                "child_stats": [],
+                "prior": 0.02669617
+              },
+              {
+                "action": 8,
+                "child_stats": [],
+                "prior": 0.050229549
+              },
+              {
+                "action": 9,
+                "child_stats": [],
+                "prior": 0.024014594
+              },
+              {
+                "action": 10,
+                "child_stats": [],
+                "prior": 0.099433094
+              },
+              {
+                "action": 11,
+                "child_stats": [],
+                "prior": 0.014508539
+              },
+              {
+                "action": 12,
+                "child_stats": [],
+                "prior": 0.025435532
+              },
+              {
+                "action": 13,
+                "child_stats": [],
+                "prior": 0.1264372
+              },
+              {
+                "action": 14,
+                "child_stats": [],
+                "prior": 0.024209971
+              },
+              {
+                "action": 15,
+                "child_stats": [],
+                "prior": 0.15585539
+              },
+              {
+                "action": 16,
+                "child_stats": [],
+                "prior": 0.020877717
+              },
+              {
+                "action": 17,
+                "child_stats": [],
+                "prior": 0.13236611
+              }
+            ],
+            "evaluation_index": 3,
+            "prior": 0.29194167,
+            "raw_value_view": -0.95713735,
+            "reward": -0.69310451,
+            "value_view": -0.95713735,
+            "visit": 1
+          },
+          {
+            "action": 5,
+            "child_stats": [],
+            "prior": 0.0097608715
+          },
+          {
+            "action": 6,
+            "child_stats": [],
+            "prior": 0.026992723
+          },
+          {
+            "action": 7,
+            "child_stats": [],
+            "prior": 0.032404877
+          },
+          {
+            "action": 8,
+            "child_stats": [],
+            "prior": 0.026912451
+          },
+          {
+            "action": 9,
+            "child_stats": [],
+            "prior": 0.026554195
+          },
+          {
+            "action": 10,
+            "child_stats": [],
+            "prior": 0.047487263
+          },
+          {
+            "action": 11,
+            "child_stats": [],
+            "prior": 0.013062782
+          },
+          {
+            "action": 12,
+            "child_stats": [],
+            "prior": 0.025034478
+          },
+          {
+            "action": 13,
+            "child_stats": [],
+            "prior": 0.040944751
+          },
+          {
+            "action": 14,
+            "child_stats": [],
+            "prior": 0.1319294
+          },
+          {
+            "action": 15,
+            "child_stats": [],
+            "prior": 0.074475311
+          },
+          {
+            "action": 16,
+            "child_stats": [],
+            "prior": 0.10731021
+          },
+          {
+            "action": 17,
+            "child_stats": [],
+            "prior": 0.014232378
+          }
+        ],
+        "evaluation_index": 1,
+        "prior": 0.20932071,
+        "raw_value_view": 0.60014725,
+        "reward": -0.76285625,
+        "value_view": -0.52361155,
+        "visit": 2
+      },
+      {
+        "action": 8,
+        "child_stats": [],
+        "prior": 0.071543604
+      },
+      {
+        "action": 9,
+        "child_stats": [],
+        "prior": 0.023244474
+      },
+      {
+        "action": 10,
+        "child_stats": [],
+        "prior": 0.095543049
+      },
+      {
+        "action": 11,
+        "child_stats": [],
+        "prior": 0.021820975
+      },
+      {
+        "action": 12,
+        "child_stats": [],
+        "prior": 0.051323574
+      },
+      {
+        "action": 13,
+        "child_stats": [],
+        "prior": 0.014735672
+      },
+      {
+        "action": 14,
+        "child_stats": [
+          {
+            "action": 0,
+            "child_stats": [],
+            "prior": 0.010102989
+          },
+          {
+            "action": 1,
+            "child_stats": [],
+            "prior": 0.055533923
+          },
+          {
+            "action": 2,
+            "child_stats": [],
+            "prior": 0.064860411
+          },
+          {
+            "action": 3,
+            "child_stats": [],
+            "prior": 0.060301162
+          },
+          {
+            "action": 4,
+            "child_stats": [],
+            "prior": 0.022950651
+          },
+          {
+            "action": 5,
+            "child_stats": [
+              {
+                "action": 0,
+                "child_stats": [],
+                "prior": 0.0092296582
+              },
+              {
+                "action": 1,
+                "child_stats": [],
+                "prior": 0.045734089
+              },
+              {
+                "action": 2,
+                "child_stats": [],
+                "prior": 0.062806226
+              },
+              {
+                "action": 3,
+                "child_stats": [],
+                "prior": 0.052839629
+              },
+              {
+                "action": 4,
+                "child_stats": [],
+                "prior": 0.034127992
+              },
+              {
+                "action": 5,
+                "child_stats": [],
+                "prior": 0.023157101
+              },
+              {
+                "action": 6,
+                "child_stats": [],
+                "prior": 0.01804618
+              },
+              {
+                "action": 7,
+                "child_stats": [],
+                "prior": 0.11030638
+              },
+              {
+                "action": 8,
+                "child_stats": [],
+                "prior": 0.015705928
+              },
+              {
+                "action": 9,
+                "child_stats": [],
+                "prior": 0.027989954
+              },
+              {
+                "action": 10,
+                "child_stats": [],
+                "prior": 0.025170179
+              },
+              {
+                "action": 11,
+                "child_stats": [],
+                "prior": 0.026215902
+              },
+              {
+                "action": 12,
+                "child_stats": [],
+                "prior": 0.0086953202
+              },
+              {
+                "action": 13,
+                "child_stats": [],
+                "prior": 0.064260066
+              },
+              {
+                "action": 14,
+                "child_stats": [],
+                "prior": 0.030182615
+              },
+              {
+                "action": 15,
+                "child_stats": [],
+                "prior": 0.074388444
+              },
+              {
+                "action": 16,
+                "child_stats": [],
+                "prior": 0.3597734
+              },
+              {
+                "action": 17,
+                "child_stats": [],
+                "prior": 0.011370935
+              }
+            ],
+            "evaluation_index": 20,
+            "prior": 0.21142994,
+            "raw_value_view": 0.24784446,
+            "reward": 0.39690661,
+            "value_view": 0.24784446,
+            "visit": 1
+          },
+          {
+            "action": 6,
+            "child_stats": [],
+            "prior": 0.084530257
+          },
+          {
+            "action": 7,
+            "child_stats": [],
+            "prior": 0.013084219
+          },
+          {
+            "action": 8,
+            "child_stats": [],
+            "prior": 0.017266991
+          },
+          {
+            "action": 9,
+            "child_stats": [],
+            "prior": 0.0082024122
+          },
+          {
+            "action": 10,
+            "child_stats": [],
+            "prior": 0.0086687263
+          },
+          {
+            "action": 11,
+            "child_stats": [],
+            "prior": 0.019488174
+          },
+          {
+            "action": 12,
+            "child_stats": [],
+            "prior": 0.05669231
+          },
+          {
+            "action": 13,
+            "child_stats": [],
+            "prior": 0.010924294
+          },
+          {
+            "action": 14,
+            "child_stats": [
+              {
+                "action": 0,
+                "child_stats": [],
+                "prior": 0.022064818
+              },
+              {
+                "action": 1,
+                "child_stats": [],
+                "prior": 0.050641738
+              },
+              {
+                "action": 2,
+                "child_stats": [],
+                "prior": 0.080834441
+              },
+              {
+                "action": 3,
+                "child_stats": [
+                  {
+                    "action": 0,
+                    "child_stats": [],
+                    "prior": 0.027471485
+                  },
+                  {
+                    "action": 1,
+                    "child_stats": [],
+                    "prior": 0.060987376
+                  },
+                  {
+                    "action": 2,
+                    "child_stats": [],
+                    "prior": 0.0019679244
+                  },
+                  {
+                    "action": 3,
+                    "child_stats": [],
+                    "prior": 0.05168575
+                  },
+                  {
+                    "action": 4,
+                    "child_stats": [],
+                    "prior": 0.014332579
+                  },
+                  {
+                    "action": 5,
+                    "child_stats": [],
+                    "prior": 0.0068515181
+                  },
+                  {
+                    "action": 6,
+                    "child_stats": [],
+                    "prior": 0.040841907
+                  },
+                  {
+                    "action": 7,
+                    "child_stats": [
+                      {
+                        "action": 0,
+                        "child_stats": [],
+                        "prior": 0.026663324
+                      },
+                      {
+                        "action": 1,
+                        "child_stats": [],
+                        "prior": 0.048629083
+                      },
+                      {
+                        "action": 2,
+                        "child_stats": [],
+                        "prior": 0.052148104
+                      },
+                      {
+                        "action": 3,
+                        "child_stats": [],
+                        "prior": 0.070882611
+                      },
+                      {
+                        "action": 4,
+                        "child_stats": [],
+                        "prior": 0.034758762
+                      },
+                      {
+                        "action": 5,
+                        "child_stats": [],
+                        "prior": 0.0096961074
+                      },
+                      {
+                        "action": 6,
+                        "child_stats": [],
+                        "prior": 0.042870827
+                      },
+                      {
+                        "action": 7,
+                        "child_stats": [],
+                        "prior": 0.1502846
+                      },
+                      {
+                        "action": 8,
+                        "child_stats": [],
+                        "prior": 0.14707643
+                      },
+                      {
+                        "action": 9,
+                        "child_stats": [],
+                        "prior": 0.082083665
+                      },
+                      {
+                        "action": 10,
+                        "child_stats": [],
+                        "prior": 0.01768047
+                      },
+                      {
+                        "action": 11,
+                        "child_stats": [],
+                        "prior": 0.067003399
+                      },
+                      {
+                        "action": 12,
+                        "child_stats": [],
+                        "prior": 0.017952513
+                      },
+                      {
+                        "action": 13,
+                        "child_stats": [],
+                        "prior": 0.012997021
+                      },
+                      {
+                        "action": 14,
+                        "child_stats": [],
+                        "prior": 0.059550695
+                      },
+                      {
+                        "action": 15,
+                        "child_stats": [],
+                        "prior": 0.076536119
+                      },
+                      {
+                        "action": 16,
+                        "child_stats": [],
+                        "prior": 0.038866177
+                      },
+                      {
+                        "action": 17,
+                        "child_stats": [],
+                        "prior": 0.044320121
+                      }
+                    ],
+                    "evaluation_index": 32,
+                    "prior": 0.16908465,
+                    "raw_value_view": 0.87286973,
+                    "reward": -0.25321198,
+                    "value_view": 0.87286973,
+                    "visit": 1
+                  },
+                  {
+                    "action": 8,
+                    "child_stats": [],
+                    "prior": 0.073314823
+                  },
+                  {
+                    "action": 9,
+                    "child_stats": [],
+                    "prior": 0.023833958
+                  },
+                  {
+                    "action": 10,
+                    "child_stats": [
+                      {
+                        "action": 0,
+                        "child_stats": [],
+                        "prior": 0.0051417919
+                      },
+                      {
+                        "action": 1,
+                        "child_stats": [],
+                        "prior": 0.0349719
+                      },
+                      {
+                        "action": 2,
+                        "child_stats": [],
+                        "prior": 0.031885143
+                      },
+                      {
+                        "action": 3,
+                        "child_stats": [],
+                        "prior": 0.048144054
+                      },
+                      {
+                        "action": 4,
+                        "child_stats": [
+                          {
+                            "action": 0,
+                            "child_stats": [
+                              {
+                                "action": 0,
+                                "child_stats": [],
+                                "prior": 0.3288472
+                              },
+                              {
+                                "action": 1,
+                                "child_stats": [],
+                                "prior": 0.062199529
+                              },
+                              {
+                                "action": 2,
+                                "child_stats": [],
+                                "prior": 0.0081233876
+                              },
+                              {
+                                "action": 3,
+                                "child_stats": [],
+                                "prior": 0.061467204
+                              },
+                              {
+                                "action": 4,
+                                "child_stats": [],
+                                "prior": 0.037747111
+                              },
+                              {
+                                "action": 5,
+                                "child_stats": [],
+                                "prior": 0.0050917915
+                              },
+                              {
+                                "action": 6,
+                                "child_stats": [],
+                                "prior": 0.052347593
+                              },
+                              {
+                                "action": 7,
+                                "child_stats": [],
+                                "prior": 0.011047219
+                              },
+                              {
+                                "action": 8,
+                                "child_stats": [],
+                                "prior": 0.013434877
+                              },
+                              {
+                                "action": 9,
+                                "child_stats": [],
+                                "prior": 0.04443045
+                              },
+                              {
+                                "action": 10,
+                                "child_stats": [],
+                                "prior": 0.057189114
+                              },
+                              {
+                                "action": 11,
+                                "child_stats": [],
+                                "prior": 0.017044963
+                              },
+                              {
+                                "action": 12,
+                                "child_stats": [],
+                                "prior": 0.12980139
+                              },
+                              {
+                                "action": 13,
+                                "child_stats": [],
+                                "prior": 0.04397098
+                              },
+                              {
+                                "action": 14,
+                                "child_stats": [],
+                                "prior": 0.038324751
+                              },
+                              {
+                                "action": 15,
+                                "child_stats": [],
+                                "prior": 0.056933768
+                              },
+                              {
+                                "action": 16,
+                                "child_stats": [],
+                                "prior": 0.024828156
+                              },
+                              {
+                                "action": 17,
+                                "child_stats": [],
+                                "prior": 0.0071705892
+                              }
+                            ],
+                            "evaluation_index": 19,
+                            "prior": 0.11702313,
+                            "raw_value_view": 0.091598272,
+                            "reward": 0.18696904,
+                            "value_view": 0.091598272,
+                            "visit": 1
+                          },
+                          {
+                            "action": 1,
+                            "child_stats": [],
+                            "prior": 0.070544936
+                          },
+                          {
+                            "action": 2,
+                            "child_stats": [],
+                            "prior": 0.0053591332
+                          },
+                          {
+                            "action": 3,
+                            "child_stats": [],
+                            "prior": 0.0068102363
+                          },
+                          {
+                            "action": 4,
+                            "child_stats": [],
+                            "prior": 0.0081479019
+                          },
+                          {
+                            "action": 5,
+                            "child_stats": [],
+                            "prior": 0.016135396
+                          },
+                          {
+                            "action": 6,
+                            "child_stats": [],
+                            "prior": 0.032584786
+                          },
+                          {
+                            "action": 7,
+                            "child_stats": [],
+                            "prior": 0.025374684
+                          },
+                          {
+                            "action": 8,
+                            "child_stats": [],
+                            "prior": 0.036272679
+                          },
+                          {
+                            "action": 9,
+                            "child_stats": [],
+                            "prior": 0.045925274
+                          },
+                          {
+                            "action": 10,
+                            "child_stats": [],
+                            "prior": 0.081738047
+                          },
+                          {
+                            "action": 11,
+                            "child_stats": [],
+                            "prior": 0.0096528186
+                          },
+                          {
+                            "action": 12,
+                            "child_stats": [],
+                            "prior": 0.03287359
+                          },
+                          {
+                            "action": 13,
+                            "child_stats": [],
+                            "prior": 0.014331858
+                          },
+                          {
+                            "action": 14,
+                            "child_stats": [],
+                            "prior": 0.040209491
+                          },
+                          {
+                            "action": 15,
+                            "child_stats": [],
+                            "prior": 0.083426543
+                          },
+                          {
+                            "action": 16,
+                            "child_stats": [
+                              {
+                                "action": 0,
+                                "child_stats": [],
+                                "prior": 0.016122947
+                              },
+                              {
+                                "action": 1,
+                                "child_stats": [],
+                                "prior": 0.010571479
+                              },
+                              {
+                                "action": 2,
+                                "child_stats": [],
+                                "prior": 0.055548076
+                              },
+                              {
+                                "action": 3,
+                                "child_stats": [],
+                                "prior": 0.090996794
+                              },
+                              {
+                                "action": 4,
+                                "child_stats": [],
+                                "prior": 0.085976191
+                              },
+                              {
+                                "action": 5,
+                                "child_stats": [],
+                                "prior": 0.064170465
+                              },
+                              {
+                                "action": 6,
+                                "child_stats": [],
+                                "prior": 0.044310346
+                              },
+                              {
+                                "action": 7,
+                                "child_stats": [],
+                                "prior": 0.025530444
+                              },
+                              {
+                                "action": 8,
+                                "child_stats": [],
+                                "prior": 0.086634107
+                              },
+                              {
+                                "action": 9,
+                                "child_stats": [],
+                                "prior": 0.02792307
+                              },
+                              {
+                                "action": 10,
+                                "child_stats": [],
+                                "prior": 0.08806061
+                              },
+                              {
+                                "action": 11,
+                                "child_stats": [
+                                  {
+                                    "action": 0,
+                                    "child_stats": [],
+                                    "prior": 0.072672121
+                                  },
+                                  {
+                                    "action": 1,
+                                    "child_stats": [],
+                                    "prior": 0.033059515
+                                  },
+                                  {
+                                    "action": 2,
+                                    "child_stats": [],
+                                    "prior": 0.017975893
+                                  },
+                                  {
+                                    "action": 3,
+                                    "child_stats": [],
+                                    "prior": 0.073640704
+                                  },
+                                  {
+                                    "action": 4,
+                                    "child_stats": [],
+                                    "prior": 0.038453955
+                                  },
+                                  {
+                                    "action": 5,
+                                    "child_stats": [],
+                                    "prior": 0.043098837
+                                  },
+                                  {
+                                    "action": 6,
+                                    "child_stats": [
+                                      {
+                                        "action": 0,
+                                        "child_stats": [],
+                                        "prior": 0.0076136021
+                                      },
+                                      {
+                                        "action": 1,
+                                        "child_stats": [],
+                                        "prior": 0.080043875
+                                      },
+                                      {
+                                        "action": 2,
+                                        "child_stats": [],
+                                        "prior": 0.0556053
+                                      },
+                                      {
+                                        "action": 3,
+                                        "child_stats": [],
+                                        "prior": 0.12755205
+                                      },
+                                      {
+                                        "action": 4,
+                                        "child_stats": [],
+                                        "prior": 0.028281227
+                                      },
+                                      {
+                                        "action": 5,
+                                        "child_stats": [],
+                                        "prior": 0.0528326
+                                      },
+                                      {
+                                        "action": 6,
+                                        "child_stats": [],
+                                        "prior": 0.011135524
+                                      },
+                                      {
+                                        "action": 7,
+                                        "child_stats": [],
+                                        "prior": 0.11968473
+                                      },
+                                      {
+                                        "action": 8,
+                                        "child_stats": [
+                                          {
+                                            "action": 0,
+                                            "child_stats": [],
+                                            "prior": 0.0067347498
+                                          },
+                                          {
+                                            "action": 1,
+                                            "child_stats": [],
+                                            "prior": 0.045524769
+                                          },
+                                          {
+                                            "action": 2,
+                                            "child_stats": [],
+                                            "prior": 0.081982166
+                                          },
+                                          {
+                                            "action": 3,
+                                            "child_stats": [],
+                                            "prior": 0.069508351
+                                          },
+                                          {
+                                            "action": 4,
+                                            "child_stats": [],
+                                            "prior": 0.058301318
+                                          },
+                                          {
+                                            "action": 5,
+                                            "child_stats": [],
+                                            "prior": 0.041881718
+                                          },
+                                          {
+                                            "action": 6,
+                                            "child_stats": [],
+                                            "prior": 0.06149609
+                                          },
+                                          {
+                                            "action": 7,
+                                            "child_stats": [],
+                                            "prior": 0.018372584
+                                          },
+                                          {
+                                            "action": 8,
+                                            "child_stats": [],
+                                            "prior": 0.035889313
+                                          },
+                                          {
+                                            "action": 9,
+                                            "child_stats": [],
+                                            "prior": 0.0630797
+                                          },
+                                          {
+                                            "action": 10,
+                                            "child_stats": [],
+                                            "prior": 0.071449831
+                                          },
+                                          {
+                                            "action": 11,
+                                            "child_stats": [],
+                                            "prior": 0.062937997
+                                          },
+                                          {
+                                            "action": 12,
+                                            "child_stats": [
+                                              {
+                                                "action": 0,
+                                                "child_stats": [],
+                                                "prior": 0.0068903579
+                                              },
+                                              {
+                                                "action": 1,
+                                                "child_stats": [],
+                                                "prior": 0.010897446
+                                              },
+                                              {
+                                                "action": 2,
+                                                "child_stats": [],
+                                                "prior": 0.0092339749
+                                              },
+                                              {
+                                                "action": 3,
+                                                "child_stats": [],
+                                                "prior": 0.0099866213
+                                              },
+                                              {
+                                                "action": 4,
+                                                "child_stats": [],
+                                                "prior": 0.10866231
+                                              },
+                                              {
+                                                "action": 5,
+                                                "child_stats": [],
+                                                "prior": 0.05119535
+                                              },
+                                              {
+                                                "action": 6,
+                                                "child_stats": [],
+                                                "prior": 0.051028002
+                                              },
+                                              {
+                                                "action": 7,
+                                                "child_stats": [],
+                                                "prior": 0.034301035
+                                              },
+                                              {
+                                                "action": 8,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [],
+                                                    "prior": 0.042277992
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.022484453
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.043895211
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.010708113
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.14387076
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.013436471
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.0068896729
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [],
+                                                    "prior": 0.0052059586
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.0099517172
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.016807839
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.15684371
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [],
+                                                    "prior": 0.036698122
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.079548471
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.20560233
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.037259236
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.036408007
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.0051293876
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.12698264
+                                                  }
+                                                ],
+                                                "evaluation_index": 22,
+                                                "prior": 0.13270794,
+                                                "raw_value_view": 0.46116972,
+                                                "reward": -0.5003562,
+                                                "value_view": 0.46116972,
+                                                "visit": 1
+                                              },
+                                              {
+                                                "action": 9,
+                                                "child_stats": [],
+                                                "prior": 0.052066009
+                                              },
+                                              {
+                                                "action": 10,
+                                                "child_stats": [],
+                                                "prior": 0.018446915
+                                              },
+                                              {
+                                                "action": 11,
+                                                "child_stats": [],
+                                                "prior": 0.019095397
+                                              },
+                                              {
+                                                "action": 12,
+                                                "child_stats": [],
+                                                "prior": 0.054604851
+                                              },
+                                              {
+                                                "action": 13,
+                                                "child_stats": [],
+                                                "prior": 0.028026288
+                                              },
+                                              {
+                                                "action": 14,
+                                                "child_stats": [],
+                                                "prior": 0.035212923
+                                              },
+                                              {
+                                                "action": 15,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [],
+                                                    "prior": 0.087663874
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.086663432
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.017513461
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.03876489
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.038318038
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.0092369169
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.0054181637
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [],
+                                                    "prior": 0.051078342
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.027010569
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.013773108
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.06491518
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [],
+                                                    "prior": 0.081451945
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.029254669
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.30203512
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.025185604
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.025520939
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.073775522
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.022420185
+                                                  }
+                                                ],
+                                                "evaluation_index": 15,
+                                                "prior": 0.24308084,
+                                                "raw_value_view": 0.25519276,
+                                                "reward": -0.87493253,
+                                                "value_view": 0.25519276,
+                                                "visit": 1
+                                              },
+                                              {
+                                                "action": 16,
+                                                "child_stats": [],
+                                                "prior": 0.099690825
+                                              },
+                                              {
+                                                "action": 17,
+                                                "child_stats": [],
+                                                "prior": 0.034872945
+                                              }
+                                            ],
+                                            "evaluation_index": 14,
+                                            "prior": 0.25476864,
+                                            "raw_value_view": 0.88797355,
+                                            "reward": -0.62716699,
+                                            "value_view": 0.075632744,
+                                            "visit": 3
+                                          },
+                                          {
+                                            "action": 13,
+                                            "child_stats": [],
+                                            "prior": 0.055537254
+                                          },
+                                          {
+                                            "action": 14,
+                                            "child_stats": [],
+                                            "prior": 0.037948586
+                                          },
+                                          {
+                                            "action": 15,
+                                            "child_stats": [],
+                                            "prior": 0.0047839261
+                                          },
+                                          {
+                                            "action": 16,
+                                            "child_stats": [],
+                                            "prior": 0.019225033
+                                          },
+                                          {
+                                            "action": 17,
+                                            "child_stats": [],
+                                            "prior": 0.010578049
+                                          }
+                                        ],
+                                        "evaluation_index": 13,
+                                        "prior": 0.16156858,
+                                        "raw_value_view": 0.47527146,
+                                        "reward": 0.57127142,
+                                        "value_view": -0.295003,
+                                        "visit": 4
+                                      },
+                                      {
+                                        "action": 9,
+                                        "child_stats": [],
+                                        "prior": 0.026741609
+                                      },
+                                      {
+                                        "action": 10,
+                                        "child_stats": [],
+                                        "prior": 0.019306833
+                                      },
+                                      {
+                                        "action": 11,
+                                        "child_stats": [],
+                                        "prior": 0.031059984
+                                      },
+                                      {
+                                        "action": 12,
+                                        "child_stats": [],
+                                        "prior": 0.05719367
+                                      },
+                                      {
+                                        "action": 13,
+                                        "child_stats": [],
+                                        "prior": 0.010869574
+                                      },
+                                      {
+                                        "action": 14,
+                                        "child_stats": [
+                                          {
+                                            "action": 0,
+                                            "child_stats": [],
+                                            "prior": 0.097693957
+                                          },
+                                          {
+                                            "action": 1,
+                                            "child_stats": [],
+                                            "prior": 0.024041902
+                                          },
+                                          {
+                                            "action": 2,
+                                            "child_stats": [],
+                                            "prior": 0.030193988
+                                          },
+                                          {
+                                            "action": 3,
+                                            "child_stats": [],
+                                            "prior": 0.031401839
+                                          },
+                                          {
+                                            "action": 4,
+                                            "child_stats": [],
+                                            "prior": 0.0085882489
+                                          },
+                                          {
+                                            "action": 5,
+                                            "child_stats": [],
+                                            "prior": 0.13817105
+                                          },
+                                          {
+                                            "action": 6,
+                                            "child_stats": [],
+                                            "prior": 0.048315004
+                                          },
+                                          {
+                                            "action": 7,
+                                            "child_stats": [],
+                                            "prior": 0.078385845
+                                          },
+                                          {
+                                            "action": 8,
+                                            "child_stats": [],
+                                            "prior": 0.048738707
+                                          },
+                                          {
+                                            "action": 9,
+                                            "child_stats": [],
+                                            "prior": 0.099584036
+                                          },
+                                          {
+                                            "action": 10,
+                                            "child_stats": [],
+                                            "prior": 0.010223388
+                                          },
+                                          {
+                                            "action": 11,
+                                            "child_stats": [],
+                                            "prior": 0.0029417214
+                                          },
+                                          {
+                                            "action": 12,
+                                            "child_stats": [],
+                                            "prior": 0.026622456
+                                          },
+                                          {
+                                            "action": 13,
+                                            "child_stats": [],
+                                            "prior": 0.023990827
+                                          },
+                                          {
+                                            "action": 14,
+                                            "child_stats": [],
+                                            "prior": 0.019896839
+                                          },
+                                          {
+                                            "action": 15,
+                                            "child_stats": [],
+                                            "prior": 0.21856244
+                                          },
+                                          {
+                                            "action": 16,
+                                            "child_stats": [],
+                                            "prior": 0.071355641
+                                          },
+                                          {
+                                            "action": 17,
+                                            "child_stats": [],
+                                            "prior": 0.021292185
+                                          }
+                                        ],
+                                        "evaluation_index": 21,
+                                        "prior": 0.1490722,
+                                        "raw_value_view": -0.11205006,
+                                        "reward": 0.47652864,
+                                        "value_view": -0.11205006,
+                                        "visit": 1
+                                      },
+                                      {
+                                        "action": 15,
+                                        "child_stats": [],
+                                        "prior": 0.028505936
+                                      },
+                                      {
+                                        "action": 16,
+                                        "child_stats": [],
+                                        "prior": 0.024095045
+                                      },
+                                      {
+                                        "action": 17,
+                                        "child_stats": [],
+                                        "prior": 0.0088376813
+                                      }
+                                    ],
+                                    "evaluation_index": 12,
+                                    "prior": 0.1117022,
+                                    "raw_value_view": 0.92464685,
+                                    "reward": -0.29944229,
+                                    "value_view": 0.39967921,
+                                    "visit": 6
+                                  },
+                                  {
+                                    "action": 7,
+                                    "child_stats": [],
+                                    "prior": 0.0060504479
+                                  },
+                                  {
+                                    "action": 8,
+                                    "child_stats": [],
+                                    "prior": 0.010138465
+                                  },
+                                  {
+                                    "action": 9,
+                                    "child_stats": [],
+                                    "prior": 0.037133005
+                                  },
+                                  {
+                                    "action": 10,
+                                    "child_stats": [
+                                      {
+                                        "action": 0,
+                                        "child_stats": [],
+                                        "prior": 0.066895947
+                                      },
+                                      {
+                                        "action": 1,
+                                        "child_stats": [
+                                          {
+                                            "action": 0,
+                                            "child_stats": [],
+                                            "prior": 0.018709283
+                                          },
+                                          {
+                                            "action": 1,
+                                            "child_stats": [
+                                              {
+                                                "action": 0,
+                                                "child_stats": [],
+                                                "prior": 0.055086676
+                                              },
+                                              {
+                                                "action": 1,
+                                                "child_stats": [],
+                                                "prior": 0.020463746
+                                              },
+                                              {
+                                                "action": 2,
+                                                "child_stats": [],
+                                                "prior": 0.013810589
+                                              },
+                                              {
+                                                "action": 3,
+                                                "child_stats": [],
+                                                "prior": 0.036142506
+                                              },
+                                              {
+                                                "action": 4,
+                                                "child_stats": [],
+                                                "prior": 0.03134333
+                                              },
+                                              {
+                                                "action": 5,
+                                                "child_stats": [],
+                                                "prior": 0.047266871
+                                              },
+                                              {
+                                                "action": 6,
+                                                "child_stats": [],
+                                                "prior": 0.035248324
+                                              },
+                                              {
+                                                "action": 7,
+                                                "child_stats": [],
+                                                "prior": 0.037385996
+                                              },
+                                              {
+                                                "action": 8,
+                                                "child_stats": [],
+                                                "prior": 0.039049808
+                                              },
+                                              {
+                                                "action": 9,
+                                                "child_stats": [],
+                                                "prior": 0.022563057
+                                              },
+                                              {
+                                                "action": 10,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [
+                                                      {
+                                                        "action": 0,
+                                                        "child_stats": [],
+                                                        "prior": 0.010500348
+                                                      },
+                                                      {
+                                                        "action": 1,
+                                                        "child_stats": [],
+                                                        "prior": 0.049958508
+                                                      },
+                                                      {
+                                                        "action": 2,
+                                                        "child_stats": [],
+                                                        "prior": 0.016520413
+                                                      },
+                                                      {
+                                                        "action": 3,
+                                                        "child_stats": [],
+                                                        "prior": 0.054853044
+                                                      },
+                                                      {
+                                                        "action": 4,
+                                                        "child_stats": [
+                                                          {
+                                                            "action": 0,
+                                                            "child_stats": [],
+                                                            "prior": 0.0534232
+                                                          },
+                                                          {
+                                                            "action": 1,
+                                                            "child_stats": [],
+                                                            "prior": 0.33918065
+                                                          },
+                                                          {
+                                                            "action": 2,
+                                                            "child_stats": [],
+                                                            "prior": 0.0097631775
+                                                          },
+                                                          {
+                                                            "action": 3,
+                                                            "child_stats": [],
+                                                            "prior": 0.075703569
+                                                          },
+                                                          {
+                                                            "action": 4,
+                                                            "child_stats": [],
+                                                            "prior": 0.021012118
+                                                          },
+                                                          {
+                                                            "action": 5,
+                                                            "child_stats": [],
+                                                            "prior": 0.031535074
+                                                          },
+                                                          {
+                                                            "action": 6,
+                                                            "child_stats": [],
+                                                            "prior": 0.058481138
+                                                          },
+                                                          {
+                                                            "action": 7,
+                                                            "child_stats": [],
+                                                            "prior": 0.016194087
+                                                          },
+                                                          {
+                                                            "action": 8,
+                                                            "child_stats": [],
+                                                            "prior": 0.020494742
+                                                          },
+                                                          {
+                                                            "action": 9,
+                                                            "child_stats": [],
+                                                            "prior": 0.069290109
+                                                          },
+                                                          {
+                                                            "action": 10,
+                                                            "child_stats": [],
+                                                            "prior": 0.049329657
+                                                          },
+                                                          {
+                                                            "action": 11,
+                                                            "child_stats": [],
+                                                            "prior": 0.025429271
+                                                          },
+                                                          {
+                                                            "action": 12,
+                                                            "child_stats": [],
+                                                            "prior": 0.037709076
+                                                          },
+                                                          {
+                                                            "action": 13,
+                                                            "child_stats": [],
+                                                            "prior": 0.014970434
+                                                          },
+                                                          {
+                                                            "action": 14,
+                                                            "child_stats": [],
+                                                            "prior": 0.039155331
+                                                          },
+                                                          {
+                                                            "action": 15,
+                                                            "child_stats": [],
+                                                            "prior": 0.018232226
+                                                          },
+                                                          {
+                                                            "action": 16,
+                                                            "child_stats": [],
+                                                            "prior": 0.054125506
+                                                          },
+                                                          {
+                                                            "action": 17,
+                                                            "child_stats": [],
+                                                            "prior": 0.065970682
+                                                          }
+                                                        ],
+                                                        "evaluation_index": 28,
+                                                        "prior": 0.20786874,
+                                                        "raw_value_view": -0.11850023,
+                                                        "reward": -0.087061882,
+                                                        "value_view": -0.11850023,
+                                                        "visit": 1
+                                                      },
+                                                      {
+                                                        "action": 5,
+                                                        "child_stats": [],
+                                                        "prior": 0.18926455
+                                                      },
+                                                      {
+                                                        "action": 6,
+                                                        "child_stats": [],
+                                                        "prior": 0.01558282
+                                                      },
+                                                      {
+                                                        "action": 7,
+                                                        "child_stats": [],
+                                                        "prior": 0.022189366
+                                                      },
+                                                      {
+                                                        "action": 8,
+                                                        "child_stats": [],
+                                                        "prior": 0.036439069
+                                                      },
+                                                      {
+                                                        "action": 9,
+                                                        "child_stats": [],
+                                                        "prior": 0.062957436
+                                                      },
+                                                      {
+                                                        "action": 10,
+                                                        "child_stats": [],
+                                                        "prior": 0.053747281
+                                                      },
+                                                      {
+                                                        "action": 11,
+                                                        "child_stats": [],
+                                                        "prior": 0.0088792127
+                                                      },
+                                                      {
+                                                        "action": 12,
+                                                        "child_stats": [],
+                                                        "prior": 0.021021556
+                                                      },
+                                                      {
+                                                        "action": 13,
+                                                        "child_stats": [],
+                                                        "prior": 0.039429449
+                                                      },
+                                                      {
+                                                        "action": 14,
+                                                        "child_stats": [],
+                                                        "prior": 0.025338639
+                                                      },
+                                                      {
+                                                        "action": 15,
+                                                        "child_stats": [],
+                                                        "prior": 0.012921211
+                                                      },
+                                                      {
+                                                        "action": 16,
+                                                        "child_stats": [],
+                                                        "prior": 0.14930665
+                                                      },
+                                                      {
+                                                        "action": 17,
+                                                        "child_stats": [],
+                                                        "prior": 0.023221716
+                                                      }
+                                                    ],
+                                                    "evaluation_index": 26,
+                                                    "prior": 0.21378326,
+                                                    "raw_value_view": 0.50849676,
+                                                    "reward": -0.43372321,
+                                                    "value_view": 0.15164508,
+                                                    "visit": 2
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.083409965
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.055544984
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.023933297
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.042778049
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.029613972
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.041050572
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [],
+                                                    "prior": 0.012089204
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.12732138
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.027847217
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.022341032
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [],
+                                                    "prior": 0.0039340663
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.011499412
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.10262927
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.0088171307
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.019525537
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.12979175
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.044089865
+                                                  }
+                                                ],
+                                                "evaluation_index": 25,
+                                                "prior": 0.32133749,
+                                                "raw_value_view": -0.10338259,
+                                                "reward": 0.21010828,
+                                                "value_view": -0.22281624,
+                                                "visit": 3
+                                              },
+                                              {
+                                                "action": 11,
+                                                "child_stats": [],
+                                                "prior": 0.036875602
+                                              },
+                                              {
+                                                "action": 12,
+                                                "child_stats": [],
+                                                "prior": 0.006645944
+                                              },
+                                              {
+                                                "action": 13,
+                                                "child_stats": [],
+                                                "prior": 0.023668794
+                                              },
+                                              {
+                                                "action": 14,
+                                                "child_stats": [],
+                                                "prior": 0.016458692
+                                              },
+                                              {
+                                                "action": 15,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [],
+                                                    "prior": 0.096710823
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.076885201
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.030615879
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.026221102
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.03551992
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.022292761
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.065624245
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [
+                                                      {
+                                                        "action": 0,
+                                                        "child_stats": [],
+                                                        "prior": 0.0064899656
+                                                      },
+                                                      {
+                                                        "action": 1,
+                                                        "child_stats": [],
+                                                        "prior": 0.040380571
+                                                      },
+                                                      {
+                                                        "action": 2,
+                                                        "child_stats": [],
+                                                        "prior": 0.061831955
+                                                      },
+                                                      {
+                                                        "action": 3,
+                                                        "child_stats": [],
+                                                        "prior": 0.0091924323
+                                                      },
+                                                      {
+                                                        "action": 4,
+                                                        "child_stats": [],
+                                                        "prior": 0.062803283
+                                                      },
+                                                      {
+                                                        "action": 5,
+                                                        "child_stats": [],
+                                                        "prior": 0.029223647
+                                                      },
+                                                      {
+                                                        "action": 6,
+                                                        "child_stats": [],
+                                                        "prior": 0.0060745548
+                                                      },
+                                                      {
+                                                        "action": 7,
+                                                        "child_stats": [],
+                                                        "prior": 0.027293552
+                                                      },
+                                                      {
+                                                        "action": 8,
+                                                        "child_stats": [],
+                                                        "prior": 0.019825242
+                                                      },
+                                                      {
+                                                        "action": 9,
+                                                        "child_stats": [],
+                                                        "prior": 0.042817399
+                                                      },
+                                                      {
+                                                        "action": 10,
+                                                        "child_stats": [],
+                                                        "prior": 0.065399483
+                                                      },
+                                                      {
+                                                        "action": 11,
+                                                        "child_stats": [],
+                                                        "prior": 0.11442512
+                                                      },
+                                                      {
+                                                        "action": 12,
+                                                        "child_stats": [],
+                                                        "prior": 0.031006234
+                                                      },
+                                                      {
+                                                        "action": 13,
+                                                        "child_stats": [],
+                                                        "prior": 0.033024587
+                                                      },
+                                                      {
+                                                        "action": 14,
+                                                        "child_stats": [],
+                                                        "prior": 0.10147816
+                                                      },
+                                                      {
+                                                        "action": 15,
+                                                        "child_stats": [],
+                                                        "prior": 0.067365251
+                                                      },
+                                                      {
+                                                        "action": 16,
+                                                        "child_stats": [],
+                                                        "prior": 0.23813461
+                                                      },
+                                                      {
+                                                        "action": 17,
+                                                        "child_stats": [],
+                                                        "prior": 0.043233927
+                                                      }
+                                                    ],
+                                                    "evaluation_index": 29,
+                                                    "prior": 0.17357482,
+                                                    "raw_value_view": -0.50768518,
+                                                    "reward": 0.89556122,
+                                                    "value_view": -0.50768518,
+                                                    "visit": 1
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.13696356
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.033366345
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.027487163
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [],
+                                                    "prior": 0.0065503353
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.10758747
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.038699348
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.038262855
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.012487111
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.059558433
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.011592624
+                                                  }
+                                                ],
+                                                "evaluation_index": 27,
+                                                "prior": 0.12958641,
+                                                "raw_value_view": 0.85109663,
+                                                "reward": -0.64613223,
+                                                "value_view": 0.62024784,
+                                                "visit": 2
+                                              },
+                                              {
+                                                "action": 16,
+                                                "child_stats": [],
+                                                "prior": 0.034493424
+                                              },
+                                              {
+                                                "action": 17,
+                                                "child_stats": [],
+                                                "prior": 0.092572756
+                                              }
+                                            ],
+                                            "evaluation_index": 24,
+                                            "prior": 0.24267101,
+                                            "raw_value_view": 0.82827783,
+                                            "reward": 0.080393076,
+                                            "value_view": 0.12277818,
+                                            "visit": 6
+                                          },
+                                          {
+                                            "action": 2,
+                                            "child_stats": [],
+                                            "prior": 0.0092752324
+                                          },
+                                          {
+                                            "action": 3,
+                                            "child_stats": [],
+                                            "prior": 0.017821912
+                                          },
+                                          {
+                                            "action": 4,
+                                            "child_stats": [],
+                                            "prior": 0.035246842
+                                          },
+                                          {
+                                            "action": 5,
+                                            "child_stats": [],
+                                            "prior": 0.0052880067
+                                          },
+                                          {
+                                            "action": 6,
+                                            "child_stats": [],
+                                            "prior": 0.061667275
+                                          },
+                                          {
+                                            "action": 7,
+                                            "child_stats": [],
+                                            "prior": 0.024912134
+                                          },
+                                          {
+                                            "action": 8,
+                                            "child_stats": [],
+                                            "prior": 0.021583719
+                                          },
+                                          {
+                                            "action": 9,
+                                            "child_stats": [
+                                              {
+                                                "action": 0,
+                                                "child_stats": [],
+                                                "prior": 0.074775398
+                                              },
+                                              {
+                                                "action": 1,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [],
+                                                    "prior": 0.037019476
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.031709809
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.030426178
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.039172638
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.013885129
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.010440307
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.1406875
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [],
+                                                    "prior": 0.11072554
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.024344783
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.018348934
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.0766102
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [
+                                                      {
+                                                        "action": 0,
+                                                        "child_stats": [],
+                                                        "prior": 0.037835553
+                                                      },
+                                                      {
+                                                        "action": 1,
+                                                        "child_stats": [],
+                                                        "prior": 0.010702266
+                                                      },
+                                                      {
+                                                        "action": 2,
+                                                        "child_stats": [],
+                                                        "prior": 0.024195028
+                                                      },
+                                                      {
+                                                        "action": 3,
+                                                        "child_stats": [],
+                                                        "prior": 0.057550617
+                                                      },
+                                                      {
+                                                        "action": 4,
+                                                        "child_stats": [],
+                                                        "prior": 0.089415461
+                                                      },
+                                                      {
+                                                        "action": 5,
+                                                        "child_stats": [],
+                                                        "prior": 0.066880383
+                                                      },
+                                                      {
+                                                        "action": 6,
+                                                        "child_stats": [
+                                                          {
+                                                            "action": 0,
+                                                            "child_stats": [],
+                                                            "prior": 0.10093725
+                                                          },
+                                                          {
+                                                            "action": 1,
+                                                            "child_stats": [],
+                                                            "prior": 0.038477328
+                                                          },
+                                                          {
+                                                            "action": 2,
+                                                            "child_stats": [],
+                                                            "prior": 0.009044488
+                                                          },
+                                                          {
+                                                            "action": 3,
+                                                            "child_stats": [],
+                                                            "prior": 0.066432066
+                                                          },
+                                                          {
+                                                            "action": 4,
+                                                            "child_stats": [],
+                                                            "prior": 0.082588136
+                                                          },
+                                                          {
+                                                            "action": 5,
+                                                            "child_stats": [],
+                                                            "prior": 0.047556709
+                                                          },
+                                                          {
+                                                            "action": 6,
+                                                            "child_stats": [
+                                                              {
+                                                                "action": 0,
+                                                                "child_stats": [],
+                                                                "prior": 0.30704021
+                                                              },
+                                                              {
+                                                                "action": 1,
+                                                                "child_stats": [],
+                                                                "prior": 0.0028836154
+                                                              },
+                                                              {
+                                                                "action": 2,
+                                                                "child_stats": [],
+                                                                "prior": 0.033963025
+                                                              },
+                                                              {
+                                                                "action": 3,
+                                                                "child_stats": [],
+                                                                "prior": 0.011416534
+                                                              },
+                                                              {
+                                                                "action": 4,
+                                                                "child_stats": [],
+                                                                "prior": 0.018841859
+                                                              },
+                                                              {
+                                                                "action": 5,
+                                                                "child_stats": [],
+                                                                "prior": 0.010784999
+                                                              },
+                                                              {
+                                                                "action": 6,
+                                                                "child_stats": [],
+                                                                "prior": 0.0061372095
+                                                              },
+                                                              {
+                                                                "action": 7,
+                                                                "child_stats": [],
+                                                                "prior": 0.050632924
+                                                              },
+                                                              {
+                                                                "action": 8,
+                                                                "child_stats": [],
+                                                                "prior": 0.0048852814
+                                                              },
+                                                              {
+                                                                "action": 9,
+                                                                "child_stats": [],
+                                                                "prior": 0.027215216
+                                                              },
+                                                              {
+                                                                "action": 10,
+                                                                "child_stats": [],
+                                                                "prior": 0.1662771
+                                                              },
+                                                              {
+                                                                "action": 11,
+                                                                "child_stats": [],
+                                                                "prior": 0.025684029
+                                                              },
+                                                              {
+                                                                "action": 12,
+                                                                "child_stats": [],
+                                                                "prior": 0.048468288
+                                                              },
+                                                              {
+                                                                "action": 13,
+                                                                "child_stats": [],
+                                                                "prior": 0.18671317
+                                                              },
+                                                              {
+                                                                "action": 14,
+                                                                "child_stats": [],
+                                                                "prior": 0.033969663
+                                                              },
+                                                              {
+                                                                "action": 15,
+                                                                "child_stats": [],
+                                                                "prior": 0.0063176304
+                                                              },
+                                                              {
+                                                                "action": 16,
+                                                                "child_stats": [],
+                                                                "prior": 0.019369029
+                                                              },
+                                                              {
+                                                                "action": 17,
+                                                                "child_stats": [],
+                                                                "prior": 0.039400283
+                                                              }
+                                                            ],
+                                                            "evaluation_index": 36,
+                                                            "prior": 0.16076829,
+                                                            "raw_value_view": -0.56153297,
+                                                            "reward": 0.16730404,
+                                                            "value_view": -0.56153297,
+                                                            "visit": 1
+                                                          },
+                                                          {
+                                                            "action": 7,
+                                                            "child_stats": [],
+                                                            "prior": 0.032554012
+                                                          },
+                                                          {
+                                                            "action": 8,
+                                                            "child_stats": [],
+                                                            "prior": 0.095683426
+                                                          },
+                                                          {
+                                                            "action": 9,
+                                                            "child_stats": [],
+                                                            "prior": 0.036668371
+                                                          },
+                                                          {
+                                                            "action": 10,
+                                                            "child_stats": [],
+                                                            "prior": 0.084360026
+                                                          },
+                                                          {
+                                                            "action": 11,
+                                                            "child_stats": [],
+                                                            "prior": 0.024220133
+                                                          },
+                                                          {
+                                                            "action": 12,
+                                                            "child_stats": [],
+                                                            "prior": 0.067465894
+                                                          },
+                                                          {
+                                                            "action": 13,
+                                                            "child_stats": [],
+                                                            "prior": 0.013549452
+                                                          },
+                                                          {
+                                                            "action": 14,
+                                                            "child_stats": [],
+                                                            "prior": 0.025282694
+                                                          },
+                                                          {
+                                                            "action": 15,
+                                                            "child_stats": [],
+                                                            "prior": 0.061202627
+                                                          },
+                                                          {
+                                                            "action": 16,
+                                                            "child_stats": [],
+                                                            "prior": 0.029697735
+                                                          },
+                                                          {
+                                                            "action": 17,
+                                                            "child_stats": [],
+                                                            "prior": 0.02351132
+                                                          }
+                                                        ],
+                                                        "evaluation_index": 35,
+                                                        "prior": 0.1230929,
+                                                        "raw_value_view": 0.91923094,
+                                                        "reward": -0.18660736,
+                                                        "value_view": 0.2633433,
+                                                        "visit": 2
+                                                      },
+                                                      {
+                                                        "action": 7,
+                                                        "child_stats": [
+                                                          {
+                                                            "action": 0,
+                                                            "child_stats": [
+                                                              {
+                                                                "action": 0,
+                                                                "child_stats": [],
+                                                                "prior": 0.053032525
+                                                              },
+                                                              {
+                                                                "action": 1,
+                                                                "child_stats": [],
+                                                                "prior": 0.041937418
+                                                              },
+                                                              {
+                                                                "action": 2,
+                                                                "child_stats": [],
+                                                                "prior": 0.095703773
+                                                              },
+                                                              {
+                                                                "action": 3,
+                                                                "child_stats": [],
+                                                                "prior": 0.023959916
+                                                              },
+                                                              {
+                                                                "action": 4,
+                                                                "child_stats": [],
+                                                                "prior": 0.05388419
+                                                              },
+                                                              {
+                                                                "action": 5,
+                                                                "child_stats": [
+                                                                  {
+                                                                    "action": 0,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.027460024
+                                                                  },
+                                                                  {
+                                                                    "action": 1,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.029476203
+                                                                  },
+                                                                  {
+                                                                    "action": 2,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.041398879
+                                                                  },
+                                                                  {
+                                                                    "action": 3,
+                                                                    "child_stats": [
+                                                                      {
+                                                                        "action": 0,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.093412809
+                                                                      },
+                                                                      {
+                                                                        "action": 1,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.061102733
+                                                                      },
+                                                                      {
+                                                                        "action": 2,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.025222687
+                                                                      },
+                                                                      {
+                                                                        "action": 3,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.025000026
+                                                                      },
+                                                                      {
+                                                                        "action": 4,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.0019585725
+                                                                      },
+                                                                      {
+                                                                        "action": 5,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.023258103
+                                                                      },
+                                                                      {
+                                                                        "action": 6,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.030816356
+                                                                      },
+                                                                      {
+                                                                        "action": 7,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.014253787
+                                                                      },
+                                                                      {
+                                                                        "action": 8,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.064371005
+                                                                      },
+                                                                      {
+                                                                        "action": 9,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.044332512
+                                                                      },
+                                                                      {
+                                                                        "action": 10,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.015312866
+                                                                      },
+                                                                      {
+                                                                        "action": 11,
+                                                                        "child_stats": [
+                                                                          {
+                                                                            "action": 0,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.085572079
+                                                                          },
+                                                                          {
+                                                                            "action": 1,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.012087836
+                                                                          },
+                                                                          {
+                                                                            "action": 2,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0025476634
+                                                                          },
+                                                                          {
+                                                                            "action": 3,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.019122114
+                                                                          },
+                                                                          {
+                                                                            "action": 4,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.02262681
+                                                                          },
+                                                                          {
+                                                                            "action": 5,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.019915581
+                                                                          },
+                                                                          {
+                                                                            "action": 6,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.019949265
+                                                                          },
+                                                                          {
+                                                                            "action": 7,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.092742823
+                                                                          },
+                                                                          {
+                                                                            "action": 8,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.041390214
+                                                                          },
+                                                                          {
+                                                                            "action": 9,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.16549771
+                                                                          },
+                                                                          {
+                                                                            "action": 10,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0077109504
+                                                                          },
+                                                                          {
+                                                                            "action": 11,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.020101506
+                                                                          },
+                                                                          {
+                                                                            "action": 12,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.33392575
+                                                                          },
+                                                                          {
+                                                                            "action": 13,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.014565559
+                                                                          },
+                                                                          {
+                                                                            "action": 14,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0089472607
+                                                                          },
+                                                                          {
+                                                                            "action": 15,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.080210805
+                                                                          },
+                                                                          {
+                                                                            "action": 16,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.013547474
+                                                                          },
+                                                                          {
+                                                                            "action": 17,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.039538667
+                                                                          }
+                                                                        ],
+                                                                        "evaluation_index": 48,
+                                                                        "prior": 0.12319162,
+                                                                        "raw_value_view": 0.5535512,
+                                                                        "reward": -0.40506458,
+                                                                        "value_view": 0.5535512,
+                                                                        "visit": 1
+                                                                      },
+                                                                      {
+                                                                        "action": 12,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.09859179
+                                                                      },
+                                                                      {
+                                                                        "action": 13,
+                                                                        "child_stats": [
+                                                                          {
+                                                                            "action": 0,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.02279193
+                                                                          },
+                                                                          {
+                                                                            "action": 1,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.11958361
+                                                                          },
+                                                                          {
+                                                                            "action": 2,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.017346589
+                                                                          },
+                                                                          {
+                                                                            "action": 3,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.026665935
+                                                                          },
+                                                                          {
+                                                                            "action": 4,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.054951772
+                                                                          },
+                                                                          {
+                                                                            "action": 5,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.041788314
+                                                                          },
+                                                                          {
+                                                                            "action": 6,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.032970399
+                                                                          },
+                                                                          {
+                                                                            "action": 7,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.01381839
+                                                                          },
+                                                                          {
+                                                                            "action": 8,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0049092271
+                                                                          },
+                                                                          {
+                                                                            "action": 9,
+                                                                            "child_stats": [
+                                                                              {
+                                                                                "action": 0,
+                                                                                "child_stats": [
+                                                                                  {
+                                                                                    "action": 0,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.094159327
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 1,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.10304391
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 2,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.0048113409
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 3,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.050857712
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 4,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.043640956
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 5,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.023322815
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 6,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.16317955
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 7,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.12543261
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 8,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.027452426
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 9,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.035003562
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 10,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.10954313
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 11,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.054631773
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 12,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.023843998
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 13,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.05970531
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 14,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.026107632
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 15,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.034715109
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 16,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.014132039
+                                                                                  },
+                                                                                  {
+                                                                                    "action": 17,
+                                                                                    "child_stats": [],
+                                                                                    "prior": 0.0064168684
+                                                                                  }
+                                                                                ],
+                                                                                "evaluation_index": 50,
+                                                                                "prior": 0.18785065,
+                                                                                "raw_value_view": -0.58822298,
+                                                                                "reward": -0.75412941,
+                                                                                "value_view": -0.58822298,
+                                                                                "visit": 1
+                                                                              },
+                                                                              {
+                                                                                "action": 1,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.029713288
+                                                                              },
+                                                                              {
+                                                                                "action": 2,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.011079057
+                                                                              },
+                                                                              {
+                                                                                "action": 3,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.056455441
+                                                                              },
+                                                                              {
+                                                                                "action": 4,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.021130832
+                                                                              },
+                                                                              {
+                                                                                "action": 5,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.034654319
+                                                                              },
+                                                                              {
+                                                                                "action": 6,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.014473215
+                                                                              },
+                                                                              {
+                                                                                "action": 7,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.074372709
+                                                                              },
+                                                                              {
+                                                                                "action": 8,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.084878787
+                                                                              },
+                                                                              {
+                                                                                "action": 9,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.0031142067
+                                                                              },
+                                                                              {
+                                                                                "action": 10,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.031842291
+                                                                              },
+                                                                              {
+                                                                                "action": 11,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.036854215
+                                                                              },
+                                                                              {
+                                                                                "action": 12,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.12271277
+                                                                              },
+                                                                              {
+                                                                                "action": 13,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.0068245544
+                                                                              },
+                                                                              {
+                                                                                "action": 14,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.063717388
+                                                                              },
+                                                                              {
+                                                                                "action": 15,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.10311526
+                                                                              },
+                                                                              {
+                                                                                "action": 16,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.027387338
+                                                                              },
+                                                                              {
+                                                                                "action": 17,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.08982373
+                                                                              }
+                                                                            ],
+                                                                            "evaluation_index": 49,
+                                                                            "prior": 0.26661199,
+                                                                            "raw_value_view": 0.83458829,
+                                                                            "reward": -0.01963973,
+                                                                            "value_view": -0.25299972,
+                                                                            "visit": 2
+                                                                          },
+                                                                          {
+                                                                            "action": 10,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.046304934
+                                                                          },
+                                                                          {
+                                                                            "action": 11,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.024371505
+                                                                          },
+                                                                          {
+                                                                            "action": 12,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.018096918
+                                                                          },
+                                                                          {
+                                                                            "action": 13,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.034510083
+                                                                          },
+                                                                          {
+                                                                            "action": 14,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.15515244
+                                                                          },
+                                                                          {
+                                                                            "action": 15,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.020368602
+                                                                          },
+                                                                          {
+                                                                            "action": 16,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.093170606
+                                                                          },
+                                                                          {
+                                                                            "action": 17,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0065867603
+                                                                          }
+                                                                        ],
+                                                                        "evaluation_index": 47,
+                                                                        "prior": 0.14075758,
+                                                                        "raw_value_view": -0.48899794,
+                                                                        "reward": 0.7630434,
+                                                                        "value_view": -0.34425294,
+                                                                        "visit": 3
+                                                                      },
+                                                                      {
+                                                                        "action": 14,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.04144793
+                                                                      },
+                                                                      {
+                                                                        "action": 15,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.03341141
+                                                                      },
+                                                                      {
+                                                                        "action": 16,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.086742893
+                                                                      },
+                                                                      {
+                                                                        "action": 17,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.076815307
+                                                                      }
+                                                                    ],
+                                                                    "evaluation_index": 46,
+                                                                    "prior": 0.17636971,
+                                                                    "raw_value_view": 0.78922629,
+                                                                    "reward": 0.23801112,
+                                                                    "value_view": 0.43910438,
+                                                                    "visit": 5
+                                                                  },
+                                                                  {
+                                                                    "action": 4,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.0083823251
+                                                                  },
+                                                                  {
+                                                                    "action": 5,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.023733215
+                                                                  },
+                                                                  {
+                                                                    "action": 6,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.027671944
+                                                                  },
+                                                                  {
+                                                                    "action": 7,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.017469499
+                                                                  },
+                                                                  {
+                                                                    "action": 8,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.019543013
+                                                                  },
+                                                                  {
+                                                                    "action": 9,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.060824983
+                                                                  },
+                                                                  {
+                                                                    "action": 10,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.02147036
+                                                                  },
+                                                                  {
+                                                                    "action": 11,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.11397457
+                                                                  },
+                                                                  {
+                                                                    "action": 12,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.044669099
+                                                                  },
+                                                                  {
+                                                                    "action": 13,
+                                                                    "child_stats": [
+                                                                      {
+                                                                        "action": 0,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.034801081
+                                                                      },
+                                                                      {
+                                                                        "action": 1,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.046157569
+                                                                      },
+                                                                      {
+                                                                        "action": 2,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.0078049679
+                                                                      },
+                                                                      {
+                                                                        "action": 3,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.045692362
+                                                                      },
+                                                                      {
+                                                                        "action": 4,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.010336152
+                                                                      },
+                                                                      {
+                                                                        "action": 5,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.016625948
+                                                                      },
+                                                                      {
+                                                                        "action": 6,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.01604913
+                                                                      },
+                                                                      {
+                                                                        "action": 7,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.07503996
+                                                                      },
+                                                                      {
+                                                                        "action": 8,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.072618313
+                                                                      },
+                                                                      {
+                                                                        "action": 9,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.05604969
+                                                                      },
+                                                                      {
+                                                                        "action": 10,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.12687542
+                                                                      },
+                                                                      {
+                                                                        "action": 11,
+                                                                        "child_stats": [
+                                                                          {
+                                                                            "action": 0,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0054106186
+                                                                          },
+                                                                          {
+                                                                            "action": 1,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.017703975
+                                                                          },
+                                                                          {
+                                                                            "action": 2,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.2804406
+                                                                          },
+                                                                          {
+                                                                            "action": 3,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.011501092
+                                                                          },
+                                                                          {
+                                                                            "action": 4,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.044178087
+                                                                          },
+                                                                          {
+                                                                            "action": 5,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.065524809
+                                                                          },
+                                                                          {
+                                                                            "action": 6,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.027880127
+                                                                          },
+                                                                          {
+                                                                            "action": 7,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.017917832
+                                                                          },
+                                                                          {
+                                                                            "action": 8,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.012813363
+                                                                          },
+                                                                          {
+                                                                            "action": 9,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0063999197
+                                                                          },
+                                                                          {
+                                                                            "action": 10,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0058669122
+                                                                          },
+                                                                          {
+                                                                            "action": 11,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.022698062
+                                                                          },
+                                                                          {
+                                                                            "action": 12,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.026044596
+                                                                          },
+                                                                          {
+                                                                            "action": 13,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.005890667
+                                                                          },
+                                                                          {
+                                                                            "action": 14,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.061391994
+                                                                          },
+                                                                          {
+                                                                            "action": 15,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.35656506
+                                                                          },
+                                                                          {
+                                                                            "action": 16,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.013315457
+                                                                          },
+                                                                          {
+                                                                            "action": 17,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.018456796
+                                                                          }
+                                                                        ],
+                                                                        "evaluation_index": 42,
+                                                                        "prior": 0.14512049,
+                                                                        "raw_value_view": 0.38094258,
+                                                                        "reward": -0.27188611,
+                                                                        "value_view": 0.38094258,
+                                                                        "visit": 1
+                                                                      },
+                                                                      {
+                                                                        "action": 12,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.026606342
+                                                                      },
+                                                                      {
+                                                                        "action": 13,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.059471495
+                                                                      },
+                                                                      {
+                                                                        "action": 14,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.029356858
+                                                                      },
+                                                                      {
+                                                                        "action": 15,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.037972737
+                                                                      },
+                                                                      {
+                                                                        "action": 16,
+                                                                        "child_stats": [
+                                                                          {
+                                                                            "action": 0,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.11852138
+                                                                          },
+                                                                          {
+                                                                            "action": 1,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.054145906
+                                                                          },
+                                                                          {
+                                                                            "action": 2,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.050611965
+                                                                          },
+                                                                          {
+                                                                            "action": 3,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.088533975
+                                                                          },
+                                                                          {
+                                                                            "action": 4,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.0091057708
+                                                                          },
+                                                                          {
+                                                                            "action": 5,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.10109358
+                                                                          },
+                                                                          {
+                                                                            "action": 6,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.036321025
+                                                                          },
+                                                                          {
+                                                                            "action": 7,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.054418165
+                                                                          },
+                                                                          {
+                                                                            "action": 8,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.056056365
+                                                                          },
+                                                                          {
+                                                                            "action": 9,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.083970562
+                                                                          },
+                                                                          {
+                                                                            "action": 10,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.043736748
+                                                                          },
+                                                                          {
+                                                                            "action": 11,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.025905386
+                                                                          },
+                                                                          {
+                                                                            "action": 12,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.033579502
+                                                                          },
+                                                                          {
+                                                                            "action": 13,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.023896184
+                                                                          },
+                                                                          {
+                                                                            "action": 14,
+                                                                            "child_stats": [
+                                                                              {
+                                                                                "action": 0,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.046709772
+                                                                              },
+                                                                              {
+                                                                                "action": 1,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.047192831
+                                                                              },
+                                                                              {
+                                                                                "action": 2,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.029068656
+                                                                              },
+                                                                              {
+                                                                                "action": 3,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.040002905
+                                                                              },
+                                                                              {
+                                                                                "action": 4,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.026316542
+                                                                              },
+                                                                              {
+                                                                                "action": 5,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.026568154
+                                                                              },
+                                                                              {
+                                                                                "action": 6,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.048887789
+                                                                              },
+                                                                              {
+                                                                                "action": 7,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.089112245
+                                                                              },
+                                                                              {
+                                                                                "action": 8,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.010515727
+                                                                              },
+                                                                              {
+                                                                                "action": 9,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.025918815
+                                                                              },
+                                                                              {
+                                                                                "action": 10,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.40614787
+                                                                              },
+                                                                              {
+                                                                                "action": 11,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.058765911
+                                                                              },
+                                                                              {
+                                                                                "action": 12,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.031599265
+                                                                              },
+                                                                              {
+                                                                                "action": 13,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.026957469
+                                                                              },
+                                                                              {
+                                                                                "action": 14,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.015844455
+                                                                              },
+                                                                              {
+                                                                                "action": 15,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.033498909
+                                                                              },
+                                                                              {
+                                                                                "action": 16,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.019054964
+                                                                              },
+                                                                              {
+                                                                                "action": 17,
+                                                                                "child_stats": [],
+                                                                                "prior": 0.017837837
+                                                                              }
+                                                                            ],
+                                                                            "evaluation_index": 44,
+                                                                            "prior": 0.15881023,
+                                                                            "raw_value_view": -0.62455273,
+                                                                            "reward": 0.267946,
+                                                                            "value_view": -0.62455273,
+                                                                            "visit": 1
+                                                                          },
+                                                                          {
+                                                                            "action": 15,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.012733681
+                                                                          },
+                                                                          {
+                                                                            "action": 16,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.034508631
+                                                                          },
+                                                                          {
+                                                                            "action": 17,
+                                                                            "child_stats": [],
+                                                                            "prior": 0.01405095
+                                                                          }
+                                                                        ],
+                                                                        "evaluation_index": 43,
+                                                                        "prior": 0.1370085,
+                                                                        "raw_value_view": -0.013767719,
+                                                                        "reward": 0.20864224,
+                                                                        "value_view": -0.18425038,
+                                                                        "visit": 2
+                                                                      },
+                                                                      {
+                                                                        "action": 17,
+                                                                        "child_stats": [],
+                                                                        "prior": 0.056412954
+                                                                      }
+                                                                    ],
+                                                                    "evaluation_index": 41,
+                                                                    "prior": 0.24603026,
+                                                                    "raw_value_view": 0.75707841,
+                                                                    "reward": 0.36293054,
+                                                                    "value_view": 0.22872032,
+                                                                    "visit": 4
+                                                                  },
+                                                                  {
+                                                                    "action": 14,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.069890574
+                                                                  },
+                                                                  {
+                                                                    "action": 15,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.027321186
+                                                                  },
+                                                                  {
+                                                                    "action": 16,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.018200111
+                                                                  },
+                                                                  {
+                                                                    "action": 17,
+                                                                    "child_stats": [],
+                                                                    "prior": 0.026114063
+                                                                  }
+                                                                ],
+                                                                "evaluation_index": 39,
+                                                                "prior": 0.255,
+                                                                "raw_value_view": 0.64899468,
+                                                                "reward": 0.60850143,
+                                                                "value_view": 0.63918442,
+                                                                "visit": 10
+                                                              },
+                                                              {
+                                                                "action": 6,
+                                                                "child_stats": [],
+                                                                "prior": 0.0086703794
+                                                              },
+                                                              {
+                                                                "action": 7,
+                                                                "child_stats": [],
+                                                                "prior": 0.024591552
+                                                              },
+                                                              {
+                                                                "action": 8,
+                                                                "child_stats": [],
+                                                                "prior": 0.011756076
+                                                              },
+                                                              {
+                                                                "action": 9,
+                                                                "child_stats": [],
+                                                                "prior": 0.013985631
+                                                              },
+                                                              {
+                                                                "action": 10,
+                                                                "child_stats": [],
+                                                                "prior": 0.019904323
+                                                              },
+                                                              {
+                                                                "action": 11,
+                                                                "child_stats": [],
+                                                                "prior": 0.027594814
+                                                              },
+                                                              {
+                                                                "action": 12,
+                                                                "child_stats": [],
+                                                                "prior": 0.21954808
+                                                              },
+                                                              {
+                                                                "action": 13,
+                                                                "child_stats": [],
+                                                                "prior": 0.04533188
+                                                              },
+                                                              {
+                                                                "action": 14,
+                                                                "child_stats": [],
+                                                                "prior": 0.038572557
+                                                              },
+                                                              {
+                                                                "action": 15,
+                                                                "child_stats": [],
+                                                                "prior": 0.030811518
+                                                              },
+                                                              {
+                                                                "action": 16,
+                                                                "child_stats": [],
+                                                                "prior": 0.015232343
+                                                              },
+                                                              {
+                                                                "action": 17,
+                                                                "child_stats": [],
+                                                                "prior": 0.020483481
+                                                              }
+                                                            ],
+                                                            "evaluation_index": 38,
+                                                            "prior": 0.29890671,
+                                                            "raw_value_view": 0.70015383,
+                                                            "reward": -0.60263276,
+                                                            "value_view": 1.196167,
+                                                            "visit": 11
+                                                          },
+                                                          {
+                                                            "action": 1,
+                                                            "child_stats": [],
+                                                            "prior": 0.10980374
+                                                          },
+                                                          {
+                                                            "action": 2,
+                                                            "child_stats": [],
+                                                            "prior": 0.015876792
+                                                          },
+                                                          {
+                                                            "action": 3,
+                                                            "child_stats": [],
+                                                            "prior": 0.0013800904
+                                                          },
+                                                          {
+                                                            "action": 4,
+                                                            "child_stats": [],
+                                                            "prior": 0.093740784
+                                                          },
+                                                          {
+                                                            "action": 5,
+                                                            "child_stats": [],
+                                                            "prior": 0.0066337013
+                                                          },
+                                                          {
+                                                            "action": 6,
+                                                            "child_stats": [],
+                                                            "prior": 0.014656494
+                                                          },
+                                                          {
+                                                            "action": 7,
+                                                            "child_stats": [],
+                                                            "prior": 0.0079743033
+                                                          },
+                                                          {
+                                                            "action": 8,
+                                                            "child_stats": [],
+                                                            "prior": 0.010734756
+                                                          },
+                                                          {
+                                                            "action": 9,
+                                                            "child_stats": [],
+                                                            "prior": 0.013108792
+                                                          },
+                                                          {
+                                                            "action": 10,
+                                                            "child_stats": [],
+                                                            "prior": 0.018247783
+                                                          },
+                                                          {
+                                                            "action": 11,
+                                                            "child_stats": [],
+                                                            "prior": 0.064453483
+                                                          },
+                                                          {
+                                                            "action": 12,
+                                                            "child_stats": [],
+                                                            "prior": 0.011261115
+                                                          },
+                                                          {
+                                                            "action": 13,
+                                                            "child_stats": [],
+                                                            "prior": 0.027005266
+                                                          },
+                                                          {
+                                                            "action": 14,
+                                                            "child_stats": [
+                                                              {
+                                                                "action": 0,
+                                                                "child_stats": [],
+                                                                "prior": 0.01859498
+                                                              },
+                                                              {
+                                                                "action": 1,
+                                                                "child_stats": [],
+                                                                "prior": 0.43324789
+                                                              },
+                                                              {
+                                                                "action": 2,
+                                                                "child_stats": [],
+                                                                "prior": 0.1014476
+                                                              },
+                                                              {
+                                                                "action": 3,
+                                                                "child_stats": [],
+                                                                "prior": 0.053989835
+                                                              },
+                                                              {
+                                                                "action": 4,
+                                                                "child_stats": [],
+                                                                "prior": 0.0363129
+                                                              },
+                                                              {
+                                                                "action": 5,
+                                                                "child_stats": [],
+                                                                "prior": 0.011666532
+                                                              },
+                                                              {
+                                                                "action": 6,
+                                                                "child_stats": [],
+                                                                "prior": 0.0039040474
+                                                              },
+                                                              {
+                                                                "action": 7,
+                                                                "child_stats": [],
+                                                                "prior": 0.032796588
+                                                              },
+                                                              {
+                                                                "action": 8,
+                                                                "child_stats": [],
+                                                                "prior": 0.035336271
+                                                              },
+                                                              {
+                                                                "action": 9,
+                                                                "child_stats": [],
+                                                                "prior": 0.020070467
+                                                              },
+                                                              {
+                                                                "action": 10,
+                                                                "child_stats": [],
+                                                                "prior": 0.023644719
+                                                              },
+                                                              {
+                                                                "action": 11,
+                                                                "child_stats": [],
+                                                                "prior": 0.051388517
+                                                              },
+                                                              {
+                                                                "action": 12,
+                                                                "child_stats": [],
+                                                                "prior": 0.031825002
+                                                              },
+                                                              {
+                                                                "action": 13,
+                                                                "child_stats": [],
+                                                                "prior": 0.0074523552
+                                                              },
+                                                              {
+                                                                "action": 14,
+                                                                "child_stats": [],
+                                                                "prior": 0.064847805
+                                                              },
+                                                              {
+                                                                "action": 15,
+                                                                "child_stats": [],
+                                                                "prior": 0.046311632
+                                                              },
+                                                              {
+                                                                "action": 16,
+                                                                "child_stats": [],
+                                                                "prior": 0.011276331
+                                                              },
+                                                              {
+                                                                "action": 17,
+                                                                "child_stats": [],
+                                                                "prior": 0.015886467
+                                                              }
+                                                            ],
+                                                            "evaluation_index": 40,
+                                                            "prior": 0.13903818,
+                                                            "raw_value_view": 0.26712942,
+                                                            "reward": -0.47984123,
+                                                            "value_view": 0.26712942,
+                                                            "visit": 1
+                                                          },
+                                                          {
+                                                            "action": 15,
+                                                            "child_stats": [],
+                                                            "prior": 0.060645938
+                                                          },
+                                                          {
+                                                            "action": 16,
+                                                            "child_stats": [],
+                                                            "prior": 0.094646871
+                                                          },
+                                                          {
+                                                            "action": 17,
+                                                            "child_stats": [],
+                                                            "prior": 0.011885184
+                                                          }
+                                                        ],
+                                                        "evaluation_index": 37,
+                                                        "prior": 0.10740212,
+                                                        "raw_value_view": 0.84684992,
+                                                        "reward": -0.1469295,
+                                                        "value_view": 0.54790306,
+                                                        "visit": 13
+                                                      },
+                                                      {
+                                                        "action": 8,
+                                                        "child_stats": [],
+                                                        "prior": 0.017881641
+                                                      },
+                                                      {
+                                                        "action": 9,
+                                                        "child_stats": [],
+                                                        "prior": 0.049230501
+                                                      },
+                                                      {
+                                                        "action": 10,
+                                                        "child_stats": [],
+                                                        "prior": 0.017730614
+                                                      },
+                                                      {
+                                                        "action": 11,
+                                                        "child_stats": [],
+                                                        "prior": 0.059924599
+                                                      },
+                                                      {
+                                                        "action": 12,
+                                                        "child_stats": [],
+                                                        "prior": 0.084445298
+                                                      },
+                                                      {
+                                                        "action": 13,
+                                                        "child_stats": [],
+                                                        "prior": 0.023145704
+                                                      },
+                                                      {
+                                                        "action": 14,
+                                                        "child_stats": [],
+                                                        "prior": 0.023741439
+                                                      },
+                                                      {
+                                                        "action": 15,
+                                                        "child_stats": [],
+                                                        "prior": 0.051254228
+                                                      },
+                                                      {
+                                                        "action": 16,
+                                                        "child_stats": [],
+                                                        "prior": 0.058525395
+                                                      },
+                                                      {
+                                                        "action": 17,
+                                                        "child_stats": [],
+                                                        "prior": 0.097046293
+                                                      }
+                                                    ],
+                                                    "evaluation_index": 34,
+                                                    "prior": 0.26702508,
+                                                    "raw_value_view": 0.59180379,
+                                                    "reward": 0.39316106,
+                                                    "value_view": 0.37093645,
+                                                    "visit": 16
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.031120731
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.070739597
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.010992752
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.0072130435
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.027293345
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.052244958
+                                                  }
+                                                ],
+                                                "evaluation_index": 31,
+                                                "prior": 0.14878649,
+                                                "raw_value_view": -0.18223405,
+                                                "reward": 0.72549152,
+                                                "value_view": 0.70738357,
+                                                "visit": 17
+                                              },
+                                              {
+                                                "action": 2,
+                                                "child_stats": [],
+                                                "prior": 0.025552433
+                                              },
+                                              {
+                                                "action": 3,
+                                                "child_stats": [],
+                                                "prior": 0.063019857
+                                              },
+                                              {
+                                                "action": 4,
+                                                "child_stats": [],
+                                                "prior": 0.037503704
+                                              },
+                                              {
+                                                "action": 5,
+                                                "child_stats": [],
+                                                "prior": 0.024207328
+                                              },
+                                              {
+                                                "action": 6,
+                                                "child_stats": [],
+                                                "prior": 0.089966625
+                                              },
+                                              {
+                                                "action": 7,
+                                                "child_stats": [],
+                                                "prior": 0.0095783845
+                                              },
+                                              {
+                                                "action": 8,
+                                                "child_stats": [],
+                                                "prior": 0.086444542
+                                              },
+                                              {
+                                                "action": 9,
+                                                "child_stats": [],
+                                                "prior": 0.042812761
+                                              },
+                                              {
+                                                "action": 10,
+                                                "child_stats": [],
+                                                "prior": 0.012159051
+                                              },
+                                              {
+                                                "action": 11,
+                                                "child_stats": [],
+                                                "prior": 0.029716238
+                                              },
+                                              {
+                                                "action": 12,
+                                                "child_stats": [],
+                                                "prior": 0.045961514
+                                              },
+                                              {
+                                                "action": 13,
+                                                "child_stats": [],
+                                                "prior": 0.044177655
+                                              },
+                                              {
+                                                "action": 14,
+                                                "child_stats": [
+                                                  {
+                                                    "action": 0,
+                                                    "child_stats": [],
+                                                    "prior": 0.049417481
+                                                  },
+                                                  {
+                                                    "action": 1,
+                                                    "child_stats": [],
+                                                    "prior": 0.081354745
+                                                  },
+                                                  {
+                                                    "action": 2,
+                                                    "child_stats": [],
+                                                    "prior": 0.033622511
+                                                  },
+                                                  {
+                                                    "action": 3,
+                                                    "child_stats": [],
+                                                    "prior": 0.059504233
+                                                  },
+                                                  {
+                                                    "action": 4,
+                                                    "child_stats": [],
+                                                    "prior": 0.011686346
+                                                  },
+                                                  {
+                                                    "action": 5,
+                                                    "child_stats": [],
+                                                    "prior": 0.033303417
+                                                  },
+                                                  {
+                                                    "action": 6,
+                                                    "child_stats": [],
+                                                    "prior": 0.020295337
+                                                  },
+                                                  {
+                                                    "action": 7,
+                                                    "child_stats": [],
+                                                    "prior": 0.024319312
+                                                  },
+                                                  {
+                                                    "action": 8,
+                                                    "child_stats": [],
+                                                    "prior": 0.12865195
+                                                  },
+                                                  {
+                                                    "action": 9,
+                                                    "child_stats": [],
+                                                    "prior": 0.012587965
+                                                  },
+                                                  {
+                                                    "action": 10,
+                                                    "child_stats": [],
+                                                    "prior": 0.0078708874
+                                                  },
+                                                  {
+                                                    "action": 11,
+                                                    "child_stats": [],
+                                                    "prior": 0.046294663
+                                                  },
+                                                  {
+                                                    "action": 12,
+                                                    "child_stats": [],
+                                                    "prior": 0.030977137
+                                                  },
+                                                  {
+                                                    "action": 13,
+                                                    "child_stats": [],
+                                                    "prior": 0.061574072
+                                                  },
+                                                  {
+                                                    "action": 14,
+                                                    "child_stats": [],
+                                                    "prior": 0.032664482
+                                                  },
+                                                  {
+                                                    "action": 15,
+                                                    "child_stats": [],
+                                                    "prior": 0.25780344
+                                                  },
+                                                  {
+                                                    "action": 16,
+                                                    "child_stats": [],
+                                                    "prior": 0.065841869
+                                                  },
+                                                  {
+                                                    "action": 17,
+                                                    "child_stats": [],
+                                                    "prior": 0.042230185
+                                                  }
+                                                ],
+                                                "evaluation_index": 33,
+                                                "prior": 0.10074019,
+                                                "raw_value_view": 0.33215928,
+                                                "reward": 0.20931005,
+                                                "value_view": 0.33215928,
+                                                "visit": 1
+                                              },
+                                              {
+                                                "action": 15,
+                                                "child_stats": [],
+                                                "prior": 0.035580218
+                                              },
+                                              {
+                                                "action": 16,
+                                                "child_stats": [],
+                                                "prior": 0.050255395
+                                              },
+                                              {
+                                                "action": 17,
+                                                "child_stats": [],
+                                                "prior": 0.078762196
+                                              }
+                                            ],
+                                            "evaluation_index": 30,
+                                            "prior": 0.23021229,
+                                            "raw_value_view": 0.78536987,
+                                            "reward": 0.67533875,
+                                            "value_view": 1.3499286,
+                                            "visit": 19
+                                          },
+                                          {
+                                            "action": 10,
+                                            "child_stats": [],
+                                            "prior": 0.0059100376
+                                          },
+                                          {
+                                            "action": 11,
+                                            "child_stats": [],
+                                            "prior": 0.018306103
+                                          },
+                                          {
+                                            "action": 12,
+                                            "child_stats": [],
+                                            "prior": 0.043762475
+                                          },
+                                          {
+                                            "action": 13,
+                                            "child_stats": [],
+                                            "prior": 0.0034296573
+                                          },
+                                          {
+                                            "action": 14,
+                                            "child_stats": [],
+                                            "prior": 0.01009837
+                                          },
+                                          {
+                                            "action": 15,
+                                            "child_stats": [],
+                                            "prior": 0.1165216
+                                          },
+                                          {
+                                            "action": 16,
+                                            "child_stats": [],
+                                            "prior": 0.091533139
+                                          },
+                                          {
+                                            "action": 17,
+                                            "child_stats": [],
+                                            "prior": 0.043050919
+                                          }
+                                        ],
+                                        "evaluation_index": 23,
+                                        "prior": 0.076581843,
+                                        "raw_value_view": 0.25417781,
+                                        "reward": 0.68571043,
+                                        "value_view": 1.5336202,
+                                        "visit": 26
+                                      },
+                                      {
+                                        "action": 2,
+                                        "child_stats": [],
+                                        "prior": 0.0360718
+                                      },
+                                      {
+                                        "action": 3,
+                                        "child_stats": [],
+                                        "prior": 0.011308426
+                                      },
+                                      {
+                                        "action": 4,
+                                        "child_stats": [],
+                                        "prior": 0.062032297
+                                      },
+                                      {
+                                        "action": 5,
+                                        "child_stats": [],
+                                        "prior": 0.047320012
+                                      },
+                                      {
+                                        "action": 6,
+                                        "child_stats": [],
+                                        "prior": 0.017731752
+                                      },
+                                      {
+                                        "action": 7,
+                                        "child_stats": [],
+                                        "prior": 0.045951955
+                                      },
+                                      {
+                                        "action": 8,
+                                        "child_stats": [],
+                                        "prior": 0.0077923266
+                                      },
+                                      {
+                                        "action": 9,
+                                        "child_stats": [],
+                                        "prior": 0.053036898
+                                      },
+                                      {
+                                        "action": 10,
+                                        "child_stats": [],
+                                        "prior": 0.067338824
+                                      },
+                                      {
+                                        "action": 11,
+                                        "child_stats": [],
+                                        "prior": 0.027421391
+                                      },
+                                      {
+                                        "action": 12,
+                                        "child_stats": [
+                                          {
+                                            "action": 0,
+                                            "child_stats": [],
+                                            "prior": 0.092953734
+                                          },
+                                          {
+                                            "action": 1,
+                                            "child_stats": [],
+                                            "prior": 0.012698045
+                                          },
+                                          {
+                                            "action": 2,
+                                            "child_stats": [],
+                                            "prior": 0.029684532
+                                          },
+                                          {
+                                            "action": 3,
+                                            "child_stats": [
+                                              {
+                                                "action": 0,
+                                                "child_stats": [],
+                                                "prior": 0.047607049
+                                              },
+                                              {
+                                                "action": 1,
+                                                "child_stats": [],
+                                                "prior": 0.091807969
+                                              },
+                                              {
+                                                "action": 2,
+                                                "child_stats": [],
+                                                "prior": 0.10794284
+                                              },
+                                              {
+                                                "action": 3,
+                                                "child_stats": [],
+                                                "prior": 0.022074673
+                                              },
+                                              {
+                                                "action": 4,
+                                                "child_stats": [],
+                                                "prior": 0.11595276
+                                              },
+                                              {
+                                                "action": 5,
+                                                "child_stats": [],
+                                                "prior": 0.047354199
+                                              },
+                                              {
+                                                "action": 6,
+                                                "child_stats": [],
+                                                "prior": 0.036363311
+                                              },
+                                              {
+                                                "action": 7,
+                                                "child_stats": [],
+                                                "prior": 0.041275464
+                                              },
+                                              {
+                                                "action": 8,
+                                                "child_stats": [],
+                                                "prior": 0.02567688
+                                              },
+                                              {
+                                                "action": 9,
+                                                "child_stats": [],
+                                                "prior": 0.12645736
+                                              },
+                                              {
+                                                "action": 10,
+                                                "child_stats": [],
+                                                "prior": 0.088896871
+                                              },
+                                              {
+                                                "action": 11,
+                                                "child_stats": [],
+                                                "prior": 0.020716097
+                                              },
+                                              {
+                                                "action": 12,
+                                                "child_stats": [],
+                                                "prior": 0.0093166791
+                                              },
+                                              {
+                                                "action": 13,
+                                                "child_stats": [],
+                                                "prior": 0.036108043
+                                              },
+                                              {
+                                                "action": 14,
+                                                "child_stats": [],
+                                                "prior": 0.038111288
+                                              },
+                                              {
+                                                "action": 15,
+                                                "child_stats": [],
+                                                "prior": 0.072155342
+                                              },
+                                              {
+                                                "action": 16,
+                                                "child_stats": [],
+                                                "prior": 0.0270925
+                                              },
+                                              {
+                                                "action": 17,
+                                                "child_stats": [],
+                                                "prior": 0.045090679
+                                              }
+                                            ],
+                                            "evaluation_index": 18,
+                                            "prior": 0.33322382,
+                                            "raw_value_view": -0.50534558,
+                                            "reward": 0.22137952,
+                                            "value_view": -0.50534558,
+                                            "visit": 1
+                                          },
+                                          {
+                                            "action": 4,
+                                            "child_stats": [],
+                                            "prior": 0.054095548
+                                          },
+                                          {
+                                            "action": 5,
+                                            "child_stats": [],
+                                            "prior": 0.021710513
+                                          },
+                                          {
+                                            "action": 6,
+                                            "child_stats": [],
+                                            "prior": 0.053188961
+                                          },
+                                          {
+                                            "action": 7,
+                                            "child_stats": [],
+                                            "prior": 0.039175186
+                                          },
+                                          {
+                                            "action": 8,
+                                            "child_stats": [],
+                                            "prior": 0.014152962
+                                          },
+                                          {
+                                            "action": 9,
+                                            "child_stats": [],
+                                            "prior": 0.0042211665
+                                          },
+                                          {
+                                            "action": 10,
+                                            "child_stats": [],
+                                            "prior": 0.011283849
+                                          },
+                                          {
+                                            "action": 11,
+                                            "child_stats": [],
+                                            "prior": 0.013676668
+                                          },
+                                          {
+                                            "action": 12,
+                                            "child_stats": [],
+                                            "prior": 0.045438223
+                                          },
+                                          {
+                                            "action": 13,
+                                            "child_stats": [],
+                                            "prior": 0.014390694
+                                          },
+                                          {
+                                            "action": 14,
+                                            "child_stats": [],
+                                            "prior": 0.028760474
+                                          },
+                                          {
+                                            "action": 15,
+                                            "child_stats": [],
+                                            "prior": 0.0015100506
+                                          },
+                                          {
+                                            "action": 16,
+                                            "child_stats": [],
+                                            "prior": 0.024148922
+                                          },
+                                          {
+                                            "action": 17,
+                                            "child_stats": [],
+                                            "prior": 0.20568661
+                                          }
+                                        ],
+                                        "evaluation_index": 17,
+                                        "prior": 0.21871811,
+                                        "raw_value_view": 0.62538409,
+                                        "reward": 0.13376379,
+                                        "value_view": 0.17146704,
+                                        "visit": 2
+                                      },
+                                      {
+                                        "action": 13,
+                                        "child_stats": [],
+                                        "prior": 0.073622786
+                                      },
+                                      {
+                                        "action": 14,
+                                        "child_stats": [],
+                                        "prior": 0.056148965
+                                      },
+                                      {
+                                        "action": 15,
+                                        "child_stats": [],
+                                        "prior": 0.067717128
+                                      },
+                                      {
+                                        "action": 16,
+                                        "child_stats": [],
+                                        "prior": 0.032295786
+                                      },
+                                      {
+                                        "action": 17,
+                                        "child_stats": [],
+                                        "prior": 0.032013725
+                                      }
+                                    ],
+                                    "evaluation_index": 11,
+                                    "prior": 0.21564384,
+                                    "raw_value_view": 0.61142778,
+                                    "reward": -0.41198826,
+                                    "value_view": 2.0277185,
+                                    "visit": 29
+                                  },
+                                  {
+                                    "action": 11,
+                                    "child_stats": [],
+                                    "prior": 0.027925812
+                                  },
+                                  {
+                                    "action": 12,
+                                    "child_stats": [],
+                                    "prior": 0.016188916
+                                  },
+                                  {
+                                    "action": 13,
+                                    "child_stats": [],
+                                    "prior": 0.059330199
+                                  },
+                                  {
+                                    "action": 14,
+                                    "child_stats": [],
+                                    "prior": 0.064418614
+                                  },
+                                  {
+                                    "action": 15,
+                                    "child_stats": [
+                                      {
+                                        "action": 0,
+                                        "child_stats": [],
+                                        "prior": 0.025736896
+                                      },
+                                      {
+                                        "action": 1,
+                                        "child_stats": [],
+                                        "prior": 0.0048063244
+                                      },
+                                      {
+                                        "action": 2,
+                                        "child_stats": [],
+                                        "prior": 0.04830876
+                                      },
+                                      {
+                                        "action": 3,
+                                        "child_stats": [],
+                                        "prior": 0.014175159
+                                      },
+                                      {
+                                        "action": 4,
+                                        "child_stats": [],
+                                        "prior": 0.029052299
+                                      },
+                                      {
+                                        "action": 5,
+                                        "child_stats": [],
+                                        "prior": 0.022842797
+                                      },
+                                      {
+                                        "action": 6,
+                                        "child_stats": [],
+                                        "prior": 0.098399714
+                                      },
+                                      {
+                                        "action": 7,
+                                        "child_stats": [],
+                                        "prior": 0.048217099
+                                      },
+                                      {
+                                        "action": 8,
+                                        "child_stats": [],
+                                        "prior": 0.044096574
+                                      },
+                                      {
+                                        "action": 9,
+                                        "child_stats": [],
+                                        "prior": 0.044409811
+                                      },
+                                      {
+                                        "action": 10,
+                                        "child_stats": [],
+                                        "prior": 0.03433089
+                                      },
+                                      {
+                                        "action": 11,
+                                        "child_stats": [],
+                                        "prior": 0.012950594
+                                      },
+                                      {
+                                        "action": 12,
+                                        "child_stats": [],
+                                        "prior": 0.047760576
+                                      },
+                                      {
+                                        "action": 13,
+                                        "child_stats": [],
+                                        "prior": 0.075045548
+                                      },
+                                      {
+                                        "action": 14,
+                                        "child_stats": [],
+                                        "prior": 0.081719317
+                                      },
+                                      {
+                                        "action": 15,
+                                        "child_stats": [],
+                                        "prior": 0.1118236
+                                      },
+                                      {
+                                        "action": 16,
+                                        "child_stats": [],
+                                        "prior": 0.0070337113
+                                      },
+                                      {
+                                        "action": 17,
+                                        "child_stats": [],
+                                        "prior": 0.24929029
+                                      }
+                                    ],
+                                    "evaluation_index": 16,
+                                    "prior": 0.10845391,
+                                    "raw_value_view": -0.84422374,
+                                    "reward": 0.025429726,
+                                    "value_view": -0.84422374,
+                                    "visit": 1
+                                  },
+                                  {
+                                    "action": 16,
+                                    "child_stats": [],
+                                    "prior": 0.057452872
+                                  },
+                                  {
+                                    "action": 17,
+                                    "child_stats": [],
+                                    "prior": 0.0066607371
+                                  }
+                                ],
+                                "evaluation_index": 10,
+                                "prior": 0.20421717,
+                                "raw_value_view": 0.94835901,
+                                "reward": -0.24380946,
+                                "value_view": 1.2812456,
+                                "visit": 37
+                              },
+                              {
+                                "action": 12,
+                                "child_stats": [],
+                                "prior": 0.002835707
+                              },
+                              {
+                                "action": 13,
+                                "child_stats": [],
+                                "prior": 0.023934113
+                              },
+                              {
+                                "action": 14,
+                                "child_stats": [],
+                                "prior": 0.036120936
+                              },
+                              {
+                                "action": 15,
+                                "child_stats": [],
+                                "prior": 0.052914321
+                              },
+                              {
+                                "action": 16,
+                                "child_stats": [],
+                                "prior": 0.0061685801
+                              },
+                              {
+                                "action": 17,
+                                "child_stats": [],
+                                "prior": 0.077964582
+                              }
+                            ],
+                            "evaluation_index": 9,
+                            "prior": 0.29732731,
+                            "raw_value_view": -0.60481691,
+                            "reward": 0.98490119,
+                            "value_view": 0.99047637,
+                            "visit": 38
+                          },
+                          {
+                            "action": 17,
+                            "child_stats": [],
+                            "prior": 0.076262206
+                          }
+                        ],
+                        "evaluation_index": 8,
+                        "prior": 0.14699931,
+                        "raw_value_view": 0.84500289,
+                        "reward": 0.38989878,
+                        "value_view": 1.9018682,
+                        "visit": 40
+                      },
+                      {
+                        "action": 5,
+                        "child_stats": [],
+                        "prior": 0.016405646
+                      },
+                      {
+                        "action": 6,
+                        "child_stats": [
+                          {
+                            "action": 0,
+                            "child_stats": [],
+                            "prior": 0.01457939
+                          },
+                          {
+                            "action": 1,
+                            "child_stats": [],
+                            "prior": 0.11300136
+                          },
+                          {
+                            "action": 2,
+                            "child_stats": [],
+                            "prior": 0.034501497
+                          },
+                          {
+                            "action": 3,
+                            "child_stats": [],
+                            "prior": 0.018202586
+                          },
+                          {
+                            "action": 4,
+                            "child_stats": [],
+                            "prior": 0.2543579
+                          },
+                          {
+                            "action": 5,
+                            "child_stats": [],
+                            "prior": 0.028428979
+                          },
+                          {
+                            "action": 6,
+                            "child_stats": [],
+                            "prior": 0.043065619
+                          },
+                          {
+                            "action": 7,
+                            "child_stats": [],
+                            "prior": 0.035338517
+                          },
+                          {
+                            "action": 8,
+                            "child_stats": [],
+                            "prior": 0.12610058
+                          },
+                          {
+                            "action": 9,
+                            "child_stats": [],
+                            "prior": 0.034778606
+                          },
+                          {
+                            "action": 10,
+                            "child_stats": [],
+                            "prior": 0.011499653
+                          },
+                          {
+                            "action": 11,
+                            "child_stats": [],
+                            "prior": 0.016204726
+                          },
+                          {
+                            "action": 12,
+                            "child_stats": [],
+                            "prior": 0.017620057
+                          },
+                          {
+                            "action": 13,
+                            "child_stats": [],
+                            "prior": 0.027099971
+                          },
+                          {
+                            "action": 14,
+                            "child_stats": [],
+                            "prior": 0.030283242
+                          },
+                          {
+                            "action": 15,
+                            "child_stats": [],
+                            "prior": 0.11233912
+                          },
+                          {
+                            "action": 16,
+                            "child_stats": [],
+                            "prior": 0.056102373
+                          },
+                          {
+                            "action": 17,
+                            "child_stats": [],
+                            "prior": 0.026495855
+                          }
+                        ],
+                        "evaluation_index": 45,
+                        "prior": 0.13860476,
+                        "raw_value_view": 0.28536892,
+                        "reward": 0.39956141,
+                        "value_view": 0.28536892,
+                        "visit": 1
+                      },
+                      {
+                        "action": 7,
+                        "child_stats": [],
+                        "prior": 0.035014793
+                      },
+                      {
+                        "action": 8,
+                        "child_stats": [],
+                        "prior": 0.062198509
+                      },
+                      {
+                        "action": 9,
+                        "child_stats": [],
+                        "prior": 0.086842857
+                      },
+                      {
+                        "action": 10,
+                        "child_stats": [],
+                        "prior": 0.017179435
+                      },
+                      {
+                        "action": 11,
+                        "child_stats": [],
+                        "prior": 0.091356941
+                      },
+                      {
+                        "action": 12,
+                        "child_stats": [],
+                        "prior": 0.015759472
+                      },
+                      {
+                        "action": 13,
+                        "child_stats": [],
+                        "prior": 0.027775558
+                      },
+                      {
+                        "action": 14,
+                        "child_stats": [],
+                        "prior": 0.069579728
+                      },
+                      {
+                        "action": 15,
+                        "child_stats": [],
+                        "prior": 0.0084788082
+                      },
+                      {
+                        "action": 16,
+                        "child_stats": [],
+                        "prior": 0.12534273
+                      },
+                      {
+                        "action": 17,
+                        "child_stats": [],
+                        "prior": 0.038318556
+                      }
+                    ],
+                    "evaluation_index": 7,
+                    "prior": 0.19184063,
+                    "raw_value_view": 0.35206676,
+                    "reward": 0.78653789,
+                    "value_view": 2.2018714,
+                    "visit": 42
+                  },
+                  {
+                    "action": 11,
+                    "child_stats": [],
+                    "prior": 0.057202999
+                  },
+                  {
+                    "action": 12,
+                    "child_stats": [],
+                    "prior": 0.04562448
+                  },
+                  {
+                    "action": 13,
+                    "child_stats": [],
+                    "prior": 0.030145293
+                  },
+                  {
+                    "action": 14,
+                    "child_stats": [],
+                    "prior": 0.014300321
+                  },
+                  {
+                    "action": 15,
+                    "child_stats": [],
+                    "prior": 0.050858904
+                  },
+                  {
+                    "action": 16,
+                    "child_stats": [],
+                    "prior": 0.07938955
+                  },
+                  {
+                    "action": 17,
+                    "child_stats": [],
+                    "prior": 0.060265839
+                  }
+                ],
+                "evaluation_index": 6,
+                "prior": 0.11893918,
+                "raw_value_view": 0.73300958,
+                "reward": 0.70600224,
+                "value_view": 2.8769498,
+                "visit": 44
+              },
+              {
+                "action": 4,
+                "child_stats": [],
+                "prior": 0.057861175
+              },
+              {
+                "action": 5,
+                "child_stats": [],
+                "prior": 0.021650514
+              },
+              {
+                "action": 6,
+                "child_stats": [],
+                "prior": 0.0094448701
+              },
+              {
+                "action": 7,
+                "child_stats": [],
+                "prior": 0.021935716
+              },
+              {
+                "action": 8,
+                "child_stats": [],
+                "prior": 0.013250387
+              },
+              {
+                "action": 9,
+                "child_stats": [
+                  {
+                    "action": 0,
+                    "child_stats": [],
+                    "prior": 0.0091056833
+                  },
+                  {
+                    "action": 1,
+                    "child_stats": [],
+                    "prior": 0.01723489
+                  },
+                  {
+                    "action": 2,
+                    "child_stats": [],
+                    "prior": 0.0038802719
+                  },
+                  {
+                    "action": 3,
+                    "child_stats": [],
+                    "prior": 0.016242964
+                  },
+                  {
+                    "action": 4,
+                    "child_stats": [],
+                    "prior": 0.070735447
+                  },
+                  {
+                    "action": 5,
+                    "child_stats": [],
+                    "prior": 0.026526527
+                  },
+                  {
+                    "action": 6,
+                    "child_stats": [],
+                    "prior": 0.024274684
+                  },
+                  {
+                    "action": 7,
+                    "child_stats": [],
+                    "prior": 0.24445046
+                  },
+                  {
+                    "action": 8,
+                    "child_stats": [],
+                    "prior": 0.002761679
+                  },
+                  {
+                    "action": 9,
+                    "child_stats": [],
+                    "prior": 0.013681365
+                  },
+                  {
+                    "action": 10,
+                    "child_stats": [],
+                    "prior": 0.090425074
+                  },
+                  {
+                    "action": 11,
+                    "child_stats": [],
+                    "prior": 0.1867514
+                  },
+                  {
+                    "action": 12,
+                    "child_stats": [],
+                    "prior": 0.14253959
+                  },
+                  {
+                    "action": 13,
+                    "child_stats": [],
+                    "prior": 0.017094674
+                  },
+                  {
+                    "action": 14,
+                    "child_stats": [],
+                    "prior": 0.0080305012
+                  },
+                  {
+                    "action": 15,
+                    "child_stats": [],
+                    "prior": 0.03545313
+                  },
+                  {
+                    "action": 16,
+                    "child_stats": [],
+                    "prior": 0.039733984
+                  },
+                  {
+                    "action": 17,
+                    "child_stats": [],
+                    "prior": 0.051077645
+                  }
+                ],
+                "evaluation_index": 5,
+                "prior": 0.17843699,
+                "raw_value_view": 0.08703661,
+                "reward": 0.15742612,
+                "value_view": 0.08703661,
+                "visit": 1
+              },
+              {
+                "action": 10,
+                "child_stats": [],
+                "prior": 0.048373368
+              },
+              {
+                "action": 11,
+                "child_stats": [],
+                "prior": 0.04872746
+              },
+              {
+                "action": 12,
+                "child_stats": [],
+                "prior": 0.040583085
+              },
+              {
+                "action": 13,
+                "child_stats": [],
+                "prior": 0.093002215
+              },
+              {
+                "action": 14,
+                "child_stats": [],
+                "prior": 0.074306041
+              },
+              {
+                "action": 15,
+                "child_stats": [],
+                "prior": 0.034204822
+              },
+              {
+                "action": 16,
+                "child_stats": [],
+                "prior": 0.015703594
+              },
+              {
+                "action": 17,
+                "child_stats": [],
+                "prior": 0.0700396
+              }
+            ],
+            "evaluation_index": 4,
+            "prior": 0.27762625,
+            "raw_value_view": 0.51367617,
+            "reward": -0.16438866,
+            "value_view": 3.4353917,
+            "visit": 46
+          },
+          {
+            "action": 15,
+            "child_stats": [],
+            "prior": 0.033956762
+          },
+          {
+            "action": 16,
+            "child_stats": [],
+            "prior": 0.039922975
+          },
+          {
+            "action": 17,
+            "child_stats": [],
+            "prior": 0.0044574854
+          }
+        ],
+        "evaluation_index": 2,
+        "prior": 0.1116844,
+        "raw_value_view": -0.97839522,
+        "reward": 0.11306548,
+        "value_view": 3.1178679,
+        "visit": 48
+      },
+      {
+        "action": 15,
+        "child_stats": [],
+        "prior": 0.027273074
+      },
+      {
+        "action": 16,
+        "child_stats": [],
+        "prior": 0.0327482
+      },
+      {
+        "action": 17,
+        "child_stats": [],
+        "prior": 0.088696897
+      }
+    ],
+    "evaluation_index": 0,
+    "prior": 1.0,
+    "raw_value_view": 0.43683624,
+    "value_view": 2.9902523,
+    "visit": 51
+  }
+}

--- a/mctx/_src/tests/tree_test.py
+++ b/mctx/_src/tests/tree_test.py
@@ -153,13 +153,13 @@ class TreeTest(parameterized.TestCase):
   # pylint: disable=line-too-long
   @parameterized.named_parameters(
       ("muzero_norescale",
-       "../mctx/_src/tests/test_data/muzero_tree.json"),
+       "test_data/muzero_tree.json"),
       ("muzero_qtransform",
-       "../mctx/_src/tests/test_data/muzero_qtransform_tree.json"),
+       "test_data/muzero_qtransform_tree.json"),
       ("gumbel_muzero_norescale",
-       "../mctx/_src/tests/test_data/gumbel_muzero_tree.json"),
+       "test_data/gumbel_muzero_tree.json"),
       ("gumbel_muzero_reward",
-       "../mctx/_src/tests/test_data/gumbel_muzero_reward_tree.json"))
+       "test_data/gumbel_muzero_reward_tree.json"))
   # pylint: enable=line-too-long
   def test_tree(self, tree_data_path):
     with open(tree_data_path, "rb") as fd:

--- a/mctx/_src/tests/tree_test.py
+++ b/mctx/_src/tests/tree_test.py
@@ -159,7 +159,12 @@ class TreeTest(parameterized.TestCase):
       ("gumbel_muzero_norescale",
        "test_data/gumbel_muzero_tree.json"),
       ("gumbel_muzero_reward",
-       "test_data/gumbel_muzero_reward_tree.json"))
+       "test_data/gumbel_muzero_reward_tree.json"),
+      ("muzero_for_action_sequence_norescale",
+       "test_data/muzero_for_action_sequence_tree.json"),
+      ("muzero_for_action_sequence_qtransform",
+       "test_data/muzero_for_action_sequence_qtransform_tree.json"),
+  )
   # pylint: enable=line-too-long
   def test_tree(self, tree_data_path):
     with open(tree_data_path, "rb") as fd:
@@ -172,6 +177,7 @@ class TreeTest(parameterized.TestCase):
     policy_fn = dict(
         gumbel_muzero=mctx.gumbel_muzero_policy,
         muzero=mctx.muzero_policy,
+        muzero_for_action_sequence=mctx.muzero_policy_for_action_sequence,
     )[tree["algorithm"]]
 
     env_config = tree["env_config"]

--- a/mctx/_src/tests/tree_test.py
+++ b/mctx/_src/tests/tree_test.py
@@ -195,6 +195,9 @@ class TreeTest(parameterized.TestCase):
     invalid_actions = np.zeros([batch_size, num_actions])
     invalid_actions[1, 1:] = 1
     invalid_actions[2, 2:] = 1
+    if tree["algorithm"] == "muzero_for_action_sequence":
+      invalid_actions = None  # muzero_for_action_sequence does not support invalid_actions
+
 
     def run_policy():
       return policy_fn(


### PR DESCRIPTION
Add muzero policy that generates a sequence of actions instead of one action.

1. I have created a new policy+search method `muzero_policy_for_action_sequence` for simplicity and as it was not straightforward to separate the responsibilities of the search method and the policy when generating a sequence of actions (who picks the next action, what should be returned by the search function, how to use the same search method for muzero and gumbel muzero, etc.). This introduces some duplicated code (~150 lines).

2. The search tree now supports updating the root indices, i.e. the root is no more fixed to be the node with index 0.


Specifics of `muzero_policy_for_action_sequence`:
1. The search tree of one step is now reused in the next step to save on computations. [AlphaGo Zero paper](https://www.nature.com/articles/nature24270) says:
> The search tree is reused at subsequent time-steps: the child node corresponding to the played action becomes the new root node; the subtree below this child is retained along with all its statistics, while the remainder of the tree is discarded

2. When generating a new action, the root is moved one node deeper, so we make the max_depth decrease by 1.

3. `invalid_actions` are not supported as the root position in the tree changes. This is because `mctx._src.search.simulate` always starts at depth zero, taking into account the old `invalid_actions` of the initial root. To support `invalid_actions`, a redesign is needed and the following questions should be answered first: 1. Are invalid actions different for different nodes in the tree, or does only the root have invalid actions? 2. When a non-root node becomes root during the search, where should we fetch `invalid_actions` for it?

4. Once the root gets updated, `root_action_selection_fn` will be called on the new root instead of `interior_action_selection_fn` which was called when it was a non-root node. This should not be a problem since the `root_action_selection_fn` is a wrapper around `interior_action_selection_fn` that sets `depth=0`. The depth is used only to know if `invalid_actions` are applied and we explicitly do not support `invalid_actions` by rasing `NotImplementedError`.

5. Tests performed:
   - With `num_actions_to_generate==1`, the same tree is created as with the standard muzero_policy. Verified using tree traversal equivalency.
   - With `num_actions_to_generate>1`, the policy returns the actions I expect to see on a dummy example.
   - Hand inspected visualisations of the search trees created for `num_actions_to_generate \in [1,2,3]`, found no insconsistancies.